### PR TITLE
Refactor: Plan generation timeout

### DIFF
--- a/assets/js/plan_template.js
+++ b/assets/js/plan_template.js
@@ -106,6 +106,7 @@ function tableToSlots() {
 async function postPlanTemplate() {
     // remove pagination buttons
     $('#pagination').hide();
+    $('#no-valid-plan-error-msg').hide();
     // remove previous search results
     $('#tables').empty();
     document.getElementById("searchSpinner").classList.remove("visually-hidden");

--- a/assets/js/plan_template.js
+++ b/assets/js/plan_template.js
@@ -106,6 +106,8 @@ function tableToSlots() {
 async function postPlanTemplate() {
     // remove pagination buttons
     $('#pagination').hide();
+    // hide timeout alert message
+    $('#request-timeout-error-msg').addClass('d-none');
     // remove previous search results
     $('#tables').empty();
     document.getElementById("searchSpinner").classList.remove("visually-hidden");
@@ -145,7 +147,14 @@ async function postPlanTemplate() {
             $('#no-valid-plan-error-msg').addClass('d-none');
         }
     ).catch(
-        err => console.error(err)
+        err => {
+            console.error(err)
+            $('#searchSpinner').addClass("visually-hidden");
+            $('#no-valid-plan-error-msg').addClass('d-none');
+            if (err.response?.status === 408) {
+                $('#request-timeout-error-msg').removeClass('d-none');
+            }
+        }
     )
 }
 

--- a/assets/js/plan_template.js
+++ b/assets/js/plan_template.js
@@ -106,7 +106,6 @@ function tableToSlots() {
 async function postPlanTemplate() {
     // remove pagination buttons
     $('#pagination').hide();
-    $('#no-valid-plan-error-msg').hide();
     // remove previous search results
     $('#tables').empty();
     document.getElementById("searchSpinner").classList.remove("visually-hidden");

--- a/assets/js/plan_template.js
+++ b/assets/js/plan_template.js
@@ -108,6 +108,8 @@ async function postPlanTemplate() {
     $('#pagination').hide();
     // hide timeout alert message
     $('#request-timeout-error-msg').addClass('d-none');
+    // hide no result alert message
+    $('#no-valid-plan-error-msg').addClass('d-none');
     // remove previous search results
     $('#tables').empty();
     document.getElementById("searchSpinner").classList.remove("visually-hidden");

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,8 @@ require (
 	github.com/braintree/manners v0.0.0-20160418043613-82a8879fc5fd
 	github.com/gin-contrib/cors v1.3.1
 	github.com/gin-contrib/requestid v0.0.1
-	github.com/gin-gonic/gin v1.7.0
+	github.com/gin-contrib/timeout v0.0.3
+	github.com/gin-gonic/gin v1.7.2
 	github.com/go-playground/assert/v2 v2.0.1
 	github.com/go-redis/redis/v8 v8.2.3
 	github.com/golang-jwt/jwt v3.2.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -36,10 +36,12 @@ github.com/gin-contrib/requestid v0.0.1 h1:pX7Mq3+SJM29OI6WmhDDCkoIj8CFlDdcMmDuz
 github.com/gin-contrib/requestid v0.0.1/go.mod h1:qHYO+O8Oo6+l3hZHL4zXyZKDaVHbAN4XdRint4Ex4+U=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
+github.com/gin-contrib/timeout v0.0.3 h1:ysZQ7kChgqlzBkuLgwTTDjTPP2uqdI68XxRyqIFK68g=
+github.com/gin-contrib/timeout v0.0.3/go.mod h1:F3fjkmFc4I1QdF7MyVwtO6ZkPueBckNoiOVpU73HGgU=
 github.com/gin-gonic/gin v1.5.0/go.mod h1:Nd6IXA8m5kNZdNEHMBd93KT+mdY3+bewLgRvmCsR2Do=
 github.com/gin-gonic/gin v1.6.3/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwvtwp4M=
-github.com/gin-gonic/gin v1.7.0 h1:jGB9xAJQ12AIGNB4HguylppmDK1Am9ppF7XnGXXJuoU=
-github.com/gin-gonic/gin v1.7.0/go.mod h1:jD2toBW3GZUr5UMcdrwQA10I7RuaFOl/SGeDjXkfUtY=
+github.com/gin-gonic/gin v1.7.2 h1:Tg03T9yM2xa8j6I3Z3oqLaQRSmKvxPd6g/2HJ6zICFA=
+github.com/gin-gonic/gin v1.7.2/go.mod h1:jD2toBW3GZUr5UMcdrwQA10I7RuaFOl/SGeDjXkfUtY=
 github.com/go-playground/assert/v2 v2.0.1 h1:MsBgLAaY856+nPRTKrp3/OZK38U/wa0CcBYNjji3q3A=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.12.1/go.mod h1:IUMDtCfWo/w/mtMfIE/IG2K+Ey3ygWanZIBtBW0W2TM=

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -580,6 +580,9 @@ func (planner *MyPlanner) customize(ctx *gin.Context) {
 
 	c := context.WithValue(ctx, iowrappers.ContextRequestIdKey, requestid.Get(ctx))
 	planningResp := planner.Planning(c, &request, "guest")
+	if planningResp.StatusCode == RequestTimeOut {
+		ctx.JSON(http.StatusRequestTimeout, nil)
+	}
 	ctx.JSON(http.StatusOK, planningResp)
 }
 

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -296,9 +296,7 @@ func (planner *MyPlanner) cityStatsHandler(context *gin.Context) {
 }
 
 func (planner *MyPlanner) Planning(ctx context.Context, planningRequest *PlanningReq, user string) (resp PlanningResponse) {
-	var planningResponse PlanningResp
-
-	planner.Solver.Solve(ctx, planner.RedisClient, planningRequest, &planningResponse)
+	planningResponse := planner.Solver.Solve(ctx, planningRequest)
 
 	if planningResponse.Err != nil {
 		resp.Err = planningResponse.Err
@@ -580,6 +578,7 @@ func (planner *MyPlanner) customize(ctx *gin.Context) {
 
 	c := context.WithValue(ctx, iowrappers.ContextRequestIdKey, requestid.Get(ctx))
 	planningResp := planner.Planning(c, &request, "guest")
+	iowrappers.Logger.Debugf("response status code is: %d", planningResp.StatusCode)
 	if planningResp.StatusCode == RequestTimeOut {
 		ctx.JSON(http.StatusRequestTimeout, nil)
 	}

--- a/planner/solver.go
+++ b/planner/solver.go
@@ -4,6 +4,7 @@ import (
 	"container/heap"
 	"context"
 	"errors"
+	"fmt"
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 	"github.com/weihesdlegend/Vacation-planner/POI"
@@ -45,6 +46,7 @@ const (
 	ValidSolutionFound     = 200
 	InvalidRequestLocation = 400
 	NoValidSolution        = 404
+	RequestTimeOut         = 408
 	InternalError          = 500
 )
 
@@ -130,7 +132,8 @@ func (s *Solver) Solve(ctx context.Context, redisClient *iowrappers.RedisClient,
 
 		select {
 		case <-ctxTimeout.Done():
-			response.Err = errors.New("planning request timed out")
+			response.Err = fmt.Errorf("the planning request %s timed out", ctx.Value(iowrappers.ContextRequestIdKey))
+			response.ErrorCode = RequestTimeOut
 			return
 		case res := <-c:
 			response.Solutions = res.Solutions

--- a/planner/utils.go
+++ b/planner/utils.go
@@ -2,10 +2,7 @@ package planner
 
 import (
 	"errors"
-	"github.com/weihesdlegend/Vacation-planner/POI"
 	"regexp"
-	"strconv"
-	"time"
 )
 
 // validate date is in the format of yyyy-mm-dd
@@ -19,21 +16,6 @@ func validateDate(date string) error {
 		return errors.New("date format must be yyyy-mm-dd")
 	}
 	return nil
-}
-
-func toWeekday(date string) POI.Weekday {
-	datePattern := regexp.MustCompile(`(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})`)
-	dateFields := datePattern.FindStringSubmatch(date)
-	year, _ := strconv.Atoi(dateFields[1])
-	month, _ := strconv.Atoi(dateFields[2])
-	day, _ := strconv.Atoi(dateFields[3])
-	t := time.Date(year, time.Month(month), day, 0, 0, 0, 0, time.UTC)
-	return POI.Weekday(t.Weekday())
-}
-
-func toPriceLevel(priceLevel string) POI.PriceLevel {
-	price, _ := strconv.Atoi(priceLevel)
-	return POI.PriceLevel(price)
 }
 
 // validate location is in the format of city,country

--- a/templates/plan_template.html
+++ b/templates/plan_template.html
@@ -163,6 +163,10 @@
                 search with another spec.
             </div>
         </div>
+        <div class="d-flex d-none" id="request-timeout-error-msg">
+            <div class="alert alert-info" type="alert">Search request is too powerful, please try to reduce the number of time slots requested.
+            </div>
+        </div>
     </div>
     <script type="module" src="assets/js/plan_template.js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>

--- a/templates/plan_template.html
+++ b/templates/plan_template.html
@@ -163,12 +163,6 @@
                 search with another spec.
             </div>
         </div>
-        <div class="d-flex d-none" id="request-timeout-error-msg">
-            <div class="alert alert-primary" type="alert">Your plan is too powerful, sorry we cannot obtain valid plans
-                within
-                reasonable time.
-            </div>
-        </div>
     </div>
     <script type="module" src="assets/js/plan_template.js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>

--- a/templates/plan_template.html
+++ b/templates/plan_template.html
@@ -163,6 +163,12 @@
                 search with another spec.
             </div>
         </div>
+        <div class="d-flex d-none" id="request-timeout-error-msg">
+            <div class="alert alert-primary" type="alert">Your plan is too powerful, sorry we cannot obtain valid plans
+                within
+                reasonable time.
+            </div>
+        </div>
     </div>
     <script type="module" src="assets/js/plan_template.js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>

--- a/test/redis_client_mocks/cached_planning_solutions_test.go
+++ b/test/redis_client_mocks/cached_planning_solutions_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestGetCachedPlanningSolutions(t *testing.T) {
-	cacheRequest1 := iowrappers.PlanningSolutionsCacheRequest{
+	cacheRequest1 := &iowrappers.PlanningSolutionsCacheRequest{
 		Location: POI.Location{City: "Beijing", Country: "China"},
 		Intervals: []POI.TimeInterval{
 			{
@@ -22,27 +22,27 @@ func TestGetCachedPlanningSolutions(t *testing.T) {
 		},
 		PlaceCategories: []POI.PlaceCategory{POI.PlaceCategoryVisit, POI.PlaceCategoryEatery},
 	}
-	expectedCacheResponse1 := iowrappers.PlanningSolutionsResponse{}
+	expectedCacheResponse1 := &iowrappers.PlanningSolutionsResponse{}
 	expectedCacheResponse1.PlanningSolutionRecords = make([]iowrappers.PlanningSolutionRecord, 1)
 	expectedCacheResponse1.PlanningSolutionRecords[0].PlaceIDs = []string{"1", "2", "3"}
 	expectedCacheResponse1.PlanningSolutionRecords[0].ID = "33521-12533"
 
 	var err error
-	_, err = RedisClient.SavePlanningSolutions(RedisContext, cacheRequest1, expectedCacheResponse1)
+	err = RedisClient.SavePlanningSolutions(RedisContext, cacheRequest1, expectedCacheResponse1)
 	if err != nil {
 		t.Error(err)
 		return
 	}
 
-	cacheRequest2 := iowrappers.PlanningSolutionsCacheRequest{
+	cacheRequest2 := &iowrappers.PlanningSolutionsCacheRequest{
 		Location: POI.Location{City: "San Francisco", Country: "United States"},
 	}
-	expectedCacheResponse2 := iowrappers.PlanningSolutionsResponse{}
+	expectedCacheResponse2 := &iowrappers.PlanningSolutionsResponse{}
 	expectedCacheResponse2.PlanningSolutionRecords = make([]iowrappers.PlanningSolutionRecord, 1)
 	expectedCacheResponse2.PlanningSolutionRecords[0].PlaceIDs = []string{"111", "222", "333"}
 	expectedCacheResponse2.PlanningSolutionRecords[0].ID = "33522-22533"
 
-	_, err = RedisClient.SavePlanningSolutions(RedisContext, cacheRequest2, expectedCacheResponse2)
+	err = RedisClient.SavePlanningSolutions(RedisContext, cacheRequest2, expectedCacheResponse2)
 	if err != nil {
 		t.Error(err)
 		return

--- a/test/solution_candidate_selection_test.go
+++ b/test/solution_candidate_selection_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"context"
 	"github.com/weihesdlegend/Vacation-planner/planner"
 	"strconv"
 	"testing"
@@ -23,15 +24,16 @@ func TestSolutionCandidateSelection(t *testing.T) {
 	clusters[0] = places
 	err := iterator.Init([]POI.PlaceCategory{POI.PlaceCategoryEatery}, clusters)
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 	topSolutionsCount := 5
-	res := planner.FindBestPlanningSolutions(clusters, topSolutionsCount, iterator)
+	res, err := planner.FindBestPlanningSolutions(context.Background(), clusters, topSolutionsCount, iterator)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if len(res) != topSolutionsCount {
-		t.Errorf("expected number of solutions equals %d, got %d", topSolutionsCount, len(res))
-		return
+		t.Fatalf("expected number of solutions equals %d, got %d", topSolutionsCount, len(res))
 	}
 
 	expectation := []float64{98, 97, 96, 95, 94}


### PR DESCRIPTION
## Description
We often see critical errors from deployed service that requests are timing out for more than 30 seconds. For large scale computations, currently we cannot generate a solution due to the complexity. The requests should not be blocked and should be timed out within reasonable time.

## Solution
* Use `context.WithTimeout` to limit `GenerateSolutions` run time.
* Use `timeout` Gin middleware to limit regular request run time.

## Testing
- [x] Integration testing on Heroku staging
- [x] Added new unit tests

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
