### PR TITLE
Fix: broken user log in functionalities

### DIFF
--- a/iowrappers/users.go
+++ b/iowrappers/users.go
@@ -64,7 +64,7 @@ func (r *RedisClient) UpdateSearchHistory(ctx context.Context, location string, 
 		}
 	}
 
-	if reflect2.IsNil(userView.Favorites) {
+	if reflect2.IsNil(userView.Favorites.SearchHistory) {
 		userView.Favorites = &user.PersonalFavorites{SearchHistory: make(map[string]user.LastSearchRecord)}
 	}
 
@@ -135,10 +135,11 @@ func (r *RedisClient) FindUser(context context.Context, findUserBy FindUserBy, u
 	userView.Password = u["password"]
 	userView.Email = u["email"]
 	userView.UserLevel = u["user_level"]
-	userView.Favorites = &user.PersonalFavorites{}
-	err := userView.Favorites.UnmarshalBinary([]byte(u["favorites"]))
-	if err != nil {
-		return user.View{}, err
+	userView.Favorites = &user.PersonalFavorites{SearchHistory: make(map[string]user.LastSearchRecord)}
+	if u["favorites"] != "" {
+		if err := userView.Favorites.UnmarshalBinary([]byte(u["favorites"])); err != nil {
+			return user.View{}, err
+		}
 	}
 
 	return userView, nil

--- a/planner/users.go
+++ b/planner/users.go
@@ -41,6 +41,13 @@ func (planner *MyPlanner) UserEmailVerify(ctx *gin.Context) {
 		}
 	}
 	userView.UserLevel = userLevel
+	// skip email verifications on non-prod environments
+	if strings.ToLower(planner.Environment) != "production" {
+		if _, err := planner.RedisClient.CreateUser(ctx, userView, false); err != nil {
+			iowrappers.Logger.Debugf("failed to create user: %v", err)
+		}
+		return
+	}
 	if err := planner.Mailer.Send(iowrappers.EmailVerification, userView); err != nil {
 		iowrappers.Logger.Error(err)
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})


### PR DESCRIPTION
## Description
After PR# checked in, existing users cannot login to their accounts.

## Solution
* Create an empty favorites field in user views for existing users.
* Enforce user credential for non-prod environments.

## Testing
- [x] Integration testing on Heroku staging
- [ ] Added new unit tests

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
