### PR TITLE
Refactor: use channel for FindBestPlanningSolutions function response

### DIFF
--- a/planner/solver.go
+++ b/planner/solver.go
@@ -305,6 +305,7 @@ func (s *Solver) generateSolutions(ctx context.Context, req *PlanningReq, timeMa
 		})
 		if err != nil {
 			resp.ErrorCode = InternalError
+			resp.Err = err
 			return resp
 		}
 
@@ -315,6 +316,7 @@ func (s *Solver) generateSolutions(ctx context.Context, req *PlanningReq, timeMa
 		})
 		if err != nil {
 			resp.ErrorCode = InternalError
+			resp.Err = err
 			return resp
 		}
 
@@ -325,6 +327,7 @@ func (s *Solver) generateSolutions(ctx context.Context, req *PlanningReq, timeMa
 		})
 		if err != nil {
 			resp.ErrorCode = InternalError
+			resp.Err = err
 			return resp
 		}
 
@@ -337,6 +340,7 @@ func (s *Solver) generateSolutions(ctx context.Context, req *PlanningReq, timeMa
 	mdIter := &MultiDimIterator{}
 	if err := mdIter.Init(placeCategories, placeClusters); err != nil {
 		resp.ErrorCode = NoValidSolution
+		resp.Err = err
 		return resp
 	}
 

--- a/test/solution_candidate_selection_test.go
+++ b/test/solution_candidate_selection_test.go
@@ -27,17 +27,18 @@ func TestSolutionCandidateSelection(t *testing.T) {
 		t.Fatal(err)
 	}
 	topSolutionsCount := 5
-	res, err := planner.FindBestPlanningSolutions(context.Background(), clusters, topSolutionsCount, iterator)
+	res := planner.FindBestPlanningSolutions(context.Background(), clusters, topSolutionsCount, iterator)
+	resp := <-res
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if len(res) != topSolutionsCount {
+	if len(resp.Solutions) != topSolutionsCount {
 		t.Fatalf("expected number of solutions equals %d, got %d", topSolutionsCount, len(res))
 	}
 
 	expectation := []float64{98, 97, 96, 95, 94}
-	for idx, r := range res {
+	for idx, r := range resp.Solutions {
 		if r.Score != expectation[idx] {
 			t.Errorf("expected %f, got %f", expectation[idx], r.Score)
 		}


### PR DESCRIPTION
## Description
The `FindBestPlanningSolutions` method used to return `[]PlanningSolution`. The issue is when time out happens, the iterator's loop has to terminate and no meaningful result will be returned.

## Solution
* Refactor `FindBestPlanningSolutions` method to return `chan PlanningResp`.
* Refactor calling function code.
* Set context with timeout in `FindBestPlanningSolutions` parent function.

## Testing
- [x] Integration testing on Heroku staging
- [x] Updated unit tests

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
