### PR TITLE
Feature: persist user last login timestamp

### DIFF
--- a/iowrappers/transformers.go
+++ b/iowrappers/transformers.go
@@ -24,11 +24,12 @@ func geocodingResultsToGeocodeQuery(query *GeocodeQuery, results []maps.Geocodin
 
 func toRedisUserData(view *user.View) map[string]interface{} {
 	return map[string]interface{}{
-		"id":         view.ID,
-		"username":   view.Username,
-		"user_level": view.UserLevel,
-		"password":   view.Password,
-		"email":      view.Email,
-		"favorites":  view.Favorites,
+		"id":            view.ID,
+		"username":      view.Username,
+		"user_level":    view.UserLevel,
+		"password":      view.Password,
+		"email":         view.Email,
+		"favorites":     view.Favorites,
+		"lastLoginTime": view.LastLoginTime,
 	}
 }

--- a/iowrappers/users.go
+++ b/iowrappers/users.go
@@ -229,6 +229,7 @@ func (r *RedisClient) Authenticate(context context.Context, credential user.Cred
 	}
 
 	lastLoginTime := time.Now()
+	u.LastLoginTime = lastLoginTime.Format(time.RFC3339)
 	tokenExpirationTime := lastLoginTime.Add(user.JWTExpirationTime)
 	expiresAt := tokenExpirationTime.Unix() // expires after 10 days
 	jwtSigningSecret := os.Getenv("JWT_SIGNING_SECRET")

--- a/planner/users.go
+++ b/planner/users.go
@@ -99,7 +99,11 @@ func (planner *MyPlanner) userLogin(context *gin.Context) {
 func (planner *MyPlanner) loginHelper(context *gin.Context, c user.Credential, frontEndLogin bool) (loggedIn bool) {
 	logger := iowrappers.Logger
 
-	_, token, tokenExpirationTime, loginErr := planner.RedisClient.Authenticate(context, c)
+	user, token, tokenExpirationTime, loginErr := planner.RedisClient.Authenticate(context, c)
+	err := planner.RedisClient.UpdateUser(context, &user)
+	if err != nil {
+		iowrappers.Logger.Errorf("failed to update user %s: %v", user.Username, err)
+	}
 	if loginErr != nil {
 		logger.Debug(loginErr)
 

--- a/user/user.go
+++ b/user/user.go
@@ -15,21 +15,14 @@ const (
 	LevelAdmin         Level  = 1
 )
 
-type User struct {
-	ID        string `json:"id"`
-	Username  string `json:"username"`
-	Password  string `json:"password"`
-	Email     string `json:"email"`
-	UserLevel string `json:"user_level"`
-}
-
 type View struct {
-	ID        string             `json:"id"`
-	Username  string             `json:"username"`
-	Email     string             `json:"email"`
-	Password  string             `json:"password"`
-	UserLevel string             `json:"user_level"`
-	Favorites *PersonalFavorites `json:"favorites"`
+	ID            string             `json:"id"`
+	Username      string             `json:"username"`
+	Email         string             `json:"email"`
+	Password      string             `json:"password"`
+	UserLevel     string             `json:"user_level"`
+	Favorites     *PersonalFavorites `json:"favorites"`
+	LastLoginTime string             `json:"lastLoginTime"`
 }
 
 type Credential struct {
@@ -55,12 +48,6 @@ func (p *PersonalFavorites) MarshalBinary() ([]byte, error) {
 
 func (p *PersonalFavorites) UnmarshalBinary(data []byte) error {
 	return msgpack.Unmarshal(data, p)
-}
-
-type Profile struct {
-	ID               string   `json:"id"`
-	UserID           string   `json:"user_id"`
-	SavedTravelPlans []string `json:"saved_travel_plans"`
 }
 
 // TravelPlaceView reflect what users see on Front-end result tables


### PR DESCRIPTION
## Description
Persist user last login timestamp, this helps tracking user engagement with the website.

## Solution
* Add a new field in user `view` and update DB when user logs in.
* Remove unused structs.

## Testing
- [x] Integration testing on Heroku staging
- [ ] Added new unit tests

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
