### PR TITLE
Bug Fix: fix the bug where plan solver misses the last point in multi-dimensional search

### DIFF
--- a/planner/MDIter.go
+++ b/planner/MDIter.go
@@ -2,6 +2,7 @@ package planner
 
 import (
 	"errors"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/weihesdlegend/Vacation-planner/POI"
 	"github.com/weihesdlegend/Vacation-planner/matching"
@@ -10,6 +11,7 @@ import (
 type MultiDimIterator struct {
 	Categories []POI.PlaceCategory
 	Status     []int
+	Stop       bool  // indicate iterator is stopped
 	Size       []int // number of items in each category
 }
 
@@ -24,7 +26,9 @@ func (mdTagIter *MultiDimIterator) Init(categories []POI.PlaceCategory, placeClu
 	mdTagIter.Categories = categories
 	mdTagIter.Status = make([]int, len(mdTagIter.Categories))
 	mdTagIter.Size = make([]int, len(mdTagIter.Categories))
+	mdTagIter.Stop = false
 	for pos, category := range mdTagIter.Categories {
+		// Status is initialized as an all-zero vector
 		mdTagIter.Status[pos] = 0
 		mdTagIter.Size[pos] = len(placeClusters[pos])
 
@@ -37,12 +41,18 @@ func (mdTagIter *MultiDimIterator) Init(categories []POI.PlaceCategory, placeClu
 }
 
 func (mdTagIter *MultiDimIterator) HasNext() bool {
+	var hasNext = !mdTagIter.Stop
+	mdTagIter.updateStop()
+	return hasNext
+}
+
+func (mdTagIter *MultiDimIterator) updateStop() {
+	// stop if every dim in status[] has reached its last point
+	var stop = true
 	for i := range mdTagIter.Categories {
-		if mdTagIter.Status[i] < mdTagIter.Size[i]-1 {
-			return true
-		}
+		stop = stop && (mdTagIter.Status[i] == mdTagIter.Size[i]-1)
 	}
-	return false
+	mdTagIter.Stop = stop
 }
 
 func (mdTagIter *MultiDimIterator) Next() bool {

--- a/planner/MDIter.go
+++ b/planner/MDIter.go
@@ -26,7 +26,6 @@ func (mdTagIter *MultiDimIterator) Init(categories []POI.PlaceCategory, placeClu
 	mdTagIter.Categories = categories
 	mdTagIter.Status = make([]int, len(mdTagIter.Categories))
 	mdTagIter.Size = make([]int, len(mdTagIter.Categories))
-	mdTagIter.Stop = false
 	for pos, category := range mdTagIter.Categories {
 		// Status is initialized as an all-zero vector
 		mdTagIter.Status[pos] = 0

--- a/planner/solver.go
+++ b/planner/solver.go
@@ -4,13 +4,14 @@ import (
 	"container/heap"
 	"context"
 	"errors"
+	"strings"
+
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 	"github.com/weihesdlegend/Vacation-planner/POI"
 	"github.com/weihesdlegend/Vacation-planner/iowrappers"
 	"github.com/weihesdlegend/Vacation-planner/matching"
 	"github.com/yourbasic/radix"
-	"strings"
 )
 
 const (

--- a/test/solution_candidate_selection_test.go
+++ b/test/solution_candidate_selection_test.go
@@ -2,9 +2,10 @@ package test
 
 import (
 	"context"
-	"github.com/weihesdlegend/Vacation-planner/planner"
 	"strconv"
 	"testing"
+
+	"github.com/weihesdlegend/Vacation-planner/planner"
 
 	"github.com/weihesdlegend/Vacation-planner/POI"
 	"github.com/weihesdlegend/Vacation-planner/matching"
@@ -14,6 +15,7 @@ import (
 func TestSolutionCandidateSelection(t *testing.T) {
 	places := make([]matching.Place, 0)
 
+	// top five ratings are 99, 98, 97, 96, 95
 	for i := 0; i < 100; i++ {
 		places = append(places, matching.Place{Place: &POI.Place{ID: strconv.Itoa(i), Rating: float32(i), UserRatingsTotal: 9}, Price: 1})
 	}
@@ -37,7 +39,8 @@ func TestSolutionCandidateSelection(t *testing.T) {
 		t.Fatalf("expected number of solutions equals %d, got %d", topSolutionsCount, len(res))
 	}
 
-	expectation := []float64{98, 97, 96, 95, 94}
+	// Suggested top five plan scores should match top five ratings
+	expectation := []float64{99, 98, 97, 96, 95}
 	for idx, r := range resp.Solutions {
 		if r.Score != expectation[idx] {
 			t.Errorf("expected %f, got %f", expectation[idx], r.Score)


### PR DESCRIPTION
## Description
Clearly describe changes in your PR, new feature or bug fixes.

Discover that our plan solver can miss the last point in the multi-dim iterator algorithm. It was found in the associated unit test, where the top return plan is supposed to have a score of 99 instead of 98. 

## Solution

Swap the sequence of iter.Next() and createPlanningSolutionCandidate(iter,) methods
Initialize the starting status in multi-dim iterator as [0, 0, -1] instead of [0, 0, 0]. 

## Testing
- [ ] Integration testing on Heroku staging
- [x] Updated unit tests

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
