### PR TITLE
Enhancement: show alert when no travel plan is found

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -30,6 +30,13 @@ $(document).ready(() => {
         console.log(`Set the Location based on PageLoad...` + val);
         LOCATION_INPUT.value = val;
     }
+
+    // FIXME: not a clean solution, improve this after we use front-end rendering
+    const url = new URL(document.referrer);
+    if (url.pathname == "/v1/") {
+        console.debug("no planning solution is found");
+        $('#no-plan-error-alert').removeClass('d-none');
+    }
 });
 
 FORM.addEventListener('submit', () => {

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -411,8 +411,7 @@ func (p *MyPlanner) getPlanningApi(ctx *gin.Context) {
 		if planningResp.StatusCode == InvalidRequestLocation {
 			ctx.String(http.StatusBadRequest, planningResp.Err.Error())
 		} else if planningResp.StatusCode == NoValidSolution {
-			errString := "No valid travel solution is found.\nPlease try searching with a larger radius or a different price level."
-			ctx.String(http.StatusBadRequest, errString)
+			ctx.Redirect(http.StatusPermanentRedirect, "/v1/")
 		}
 		return
 	}

--- a/templates/search_page.html
+++ b/templates/search_page.html
@@ -41,7 +41,7 @@
     </div>
 
     <div class="mt-2 alert alert-danger alert-dismissible fade show d-none" role="alert" id="no-plan-error-alert">
-        No plan is found, please try searching with a larger radius or a different price level.
+        No travel plan is found, please try searching with a different criteria.
         <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
     </div>
 

--- a/templates/search_page.html
+++ b/templates/search_page.html
@@ -40,6 +40,11 @@
         </div>
     </div>
 
+    <div class="mt-2 alert alert-danger alert-dismissible fade show d-none" role="alert" id="no-plan-error-alert">
+        No plan is found, please try searching with a larger radius or a different price level.
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+
     <!--navigation bar-->
     <nav class="navbar navbar-light navbar-expand-lg" style="background-color: #e3f2fd;">
         <div class="container-fluid">


### PR DESCRIPTION
## Description
Show alert banner when no travel plan is found for searches on home page. Previously we are showing user 2 lines of strings, which is confusing and rudimentary.

## Solution
* Achieving this is tricky due to our backend rendering for standard plan results page
* Use redirect and detect this with `document.referrer` and path difference checks

## Testing
- [x] Integration testing on Heroku testing

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
