### PR TITLE
Fix: persistent alert message when back forward or reload the page

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -33,7 +33,7 @@ $(document).ready(() => {
 
     // FIXME: not a clean solution, improve this after we use front-end rendering
     const url = new URL(document.referrer);
-    if (url.pathname == "/v1/") {
+    if (url.pathname === "/v1/" && pageIsNavigated()) {
         console.debug("no planning solution is found");
         $('#no-plan-error-alert').removeClass('d-none');
     }
@@ -44,7 +44,22 @@ FORM.addEventListener('submit', () => {
         sessionStorage.setItem(STORAGE_ITEM, LOCATION_INPUT.value);
         console.log(`The location is ${LOCATION_INPUT.value}`);
     }
-})
+});
+
+function pageIsNavigated() {
+    const entries = performance.getEntriesByType("navigation");
+    let result = false;
+    entries.forEach(
+        (entry) => {
+            if (entry.type === "navigate") {
+                console.log("page is navigated");
+                result = true;
+            }
+            console.log(`page is ${entry.type}`);
+        }
+    )
+    return result;
+}
 
 document.querySelector('#autofill').addEventListener('click', locateMe);
 


### PR DESCRIPTION
## Description
The newly added alert message when no plan is not found persist when users swipe backward on phones or reload the page.

## Solution
* This change fixes the issue by making sure the navigation is of `navigate` type instead of the other types described [here](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceNavigationTiming/type).

## Testing
- [x] Integration testing on Heroku staging

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
