### PR TITLE
Feat: show plan details button on user profile page

### DIFF
--- a/assets/js/user_profile.js
+++ b/assets/js/user_profile.js
@@ -35,13 +35,21 @@ function renderCard(plan) {
     )
     cardBody.append(placeList);
     let deleteButton = $('<button>')
-        .addClass('btn btn-outline-warning float-end')
+        .addClass('btn btn-outline-warning m-1 float-end')
         .attr('type', 'button')
-        .attr('data-planId', `${plan.id}`)
+        .attr('data-planid', `${plan.id}`)
         .attr('data-user', `${username}`)
         .text('delete');
     deleteButton.click(deleteUserPlan);
     cardBody.append(deleteButton);
+
+    let showDetailsButton = $('<button>')
+        .addClass('btn btn-outline-info float-end m-1')
+        .attr('type', 'button')
+        .attr('data-planid', `${plan.original_plan_id}`)
+        .text('details');
+    showDetailsButton.click(showPlanDetails);
+    cardBody.append(showDetailsButton);
 
     card.append(cardBody);
     cards.append(card);
@@ -59,6 +67,11 @@ function renderFavorites(favorites) {
         }
     }
     mostSearchedPlace.innerText = result;
+}
+
+function showPlanDetails() {
+    const planID = this.dataset.planid;
+    window.location = `plans/${planID}`;
 }
 
 async function getUserPlans() {

--- a/assets/js/user_profile.js
+++ b/assets/js/user_profile.js
@@ -97,7 +97,9 @@ async function getUserFavorites() {
     );
 }
 
-window.onload = function () {
-    getUserPlans();
-    getUserFavorites();
-};
+async function renderUserProfile() {
+    await getUserPlans();
+    await getUserFavorites();
+}
+
+window.onload = renderUserProfile();


### PR DESCRIPTION
## Description
Add a button to direct users to plan details page for their saved plans.

## Solution
* Use `original_plan_id` field in plan views to construct URL.

## Testing
- [x] Integration testing on Heroku staging
- [ ] Added new unit tests

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
