### PR TITLE
Verify password reset requests with code

### DIFF
--- a/assets/js/forgot-password.js
+++ b/assets/js/forgot-password.js
@@ -25,14 +25,3 @@ form.addEventListener('submit', (event) => {
 
     sendDataXHR(url, "GET", {}, XHR);
 })
-
-$('#password-reset-form').submit(async () => {
-    const email = document.querySelector('#email').value;
-    const url = `/v1/send-password-reset-email?email=${email}`;
-    await axios.get(
-        url
-    ).catch(
-        err => console.error(err)
-    );
-    return false;
-})

--- a/assets/js/reset-password.js
+++ b/assets/js/reset-password.js
@@ -8,13 +8,11 @@ form.addEventListener('submit', (event) => {
     const url = new URL(document.URL);
     const email = url.searchParams.get('email');
     const code = url.searchParams.get('code');
-    const oldPassword = document.querySelector('#old-password').value;
     const newPassword = document.querySelector('#new-password').value;
 
     const data = {
         'email': email,
         'code': code,
-        'old_password': oldPassword,
         'new_password': newPassword,
     }
 

--- a/assets/js/reset-password.js
+++ b/assets/js/reset-password.js
@@ -7,11 +7,13 @@ form.addEventListener('submit', (event) => {
 
     const url = new URL(document.URL);
     const email = url.searchParams.get('email');
+    const code = url.searchParams.get('code');
     const oldPassword = document.querySelector('#old-password').value;
     const newPassword = document.querySelector('#new-password').value;
 
     const data = {
         'email': email,
+        'code': code,
         'old_password': oldPassword,
         'new_password': newPassword,
     }

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -660,6 +660,10 @@ func (p *MyPlanner) userResetPassword(ctx *gin.Context) {
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 	}
 
+	if verificationErr := p.RedisClient.VerifyPasswordResetRequest(ctx, r); verificationErr.HttpStatus != http.StatusOK {
+		ctx.JSON(verificationErr.HttpStatus, gin.H{"error": verificationErr.Message})
+	}
+
 	if err := p.RedisClient.SetPassword(ctx, r); err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 	}

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -661,7 +661,7 @@ func (p *MyPlanner) userResetPassword(ctx *gin.Context) {
 	}
 
 	if verificationErr := p.RedisClient.VerifyPasswordResetRequest(ctx, r); verificationErr.HttpStatus != http.StatusOK {
-		ctx.JSON(verificationErr.HttpStatus, gin.H{"error": verificationErr.Message})
+		ctx.JSON(verificationErr.HttpStatus, gin.H{"error": verificationErr.Message.Error()})
 	}
 
 	if err := p.RedisClient.SetPassword(ctx, r); err != nil {

--- a/templates/reset_password_page.html
+++ b/templates/reset_password_page.html
@@ -50,8 +50,6 @@
                         </div>
                         <form id="set-new-password-form">
                             <div class="mb-3">
-                                <input type="password" id="old-password" class="form-control" placeholder="Old Password"
-                                    required="true">
                                 <input type="password" id="new-password" class="form-control" placeholder="New Password"
                                     required="true">
                             </div>

--- a/user/user.go
+++ b/user/user.go
@@ -33,9 +33,10 @@ type Credential struct {
 }
 
 type PasswordResetRequest struct {
-	Email       string `json:"email"`
-	OldPassword string `json:"old_password"`
-	NewPassword string `json:"new_password"`
+	Email            string `json:"email"`
+	VerificationCode string `json:"verification_code"`
+	OldPassword      string `json:"old_password"`
+	NewPassword      string `json:"new_password"`
 }
 
 type PersonalFavorites struct {

--- a/user/user.go
+++ b/user/user.go
@@ -34,8 +34,7 @@ type Credential struct {
 
 type PasswordResetRequest struct {
 	Email            string `json:"email"`
-	VerificationCode string `json:"verification_code"`
-	OldPassword      string `json:"old_password"`
+	VerificationCode string `json:"code"`
 	NewPassword      string `json:"new_password"`
 }
 


### PR DESCRIPTION
## Description
In the previous PR, we already created a verification code for each password reset request. But we did not make proper use of it. Also users should not need old password to set new ones, otherwise why would they need to reset?

## Solution
* Verify user email against verification code to make sure URL is not tampered.
* Verify password reset code is claimed only once.
* Removed requirement for user entering old password.

## Testing
- [x] Integration testing on Heroku testing

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
