### PR TITLE
Fix: precise location flag resets when user is navigated

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -24,11 +24,22 @@ document.getElementById("logout-confirm-btn").addEventListener(
 const FORM = document.getElementById("main-form");
 const STORAGE_ITEM = "location";
 const LOCATION_INPUT = document.getElementById("location");
+
+// resets flag value whenever user manually modifies input
+LOCATION_INPUT.addEventListener('change', () => {
+    document.querySelector('#precise-location-flag').value = 'false';
+})
+
 $(document).ready(() => {
     const val = sessionStorage.getItem(STORAGE_ITEM);
     if (val) {
         console.log(`Set the Location based on PageLoad...` + val);
         LOCATION_INPUT.value = val;
+    }
+
+    const usePreciseLocation = sessionStorage.getItem('use-precise-location');
+    if (usePreciseLocation) {
+        document.querySelector('#precise-location-flag').value = usePreciseLocation;
     }
 
     // FIXME: not a clean solution, improve this after we use front-end rendering
@@ -43,6 +54,9 @@ FORM.addEventListener('submit', () => {
     if (LOCATION_INPUT.value) {
         sessionStorage.setItem(STORAGE_ITEM, LOCATION_INPUT.value);
         console.log(`The location is ${LOCATION_INPUT.value}`);
+
+        // updates stored precise location flag value upon search form submission
+        sessionStorage.setItem('use-precise-location', document.querySelector('#precise-location-flag').value);
     }
 });
 

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -488,7 +488,7 @@ func (p *MyPlanner) getPlanDetails(ctx *gin.Context) {
 		}
 
 		// Show the first place by default
-		tripResp.ShownActive = append(tripResp.ShownActive, (idx == 0))
+		tripResp.ShownActive = append(tripResp.ShownActive, idx == 0)
 
 		// Run Goroutines to retrieve place details
 		go p.asyncGetTripRespPlaceDetails(&wg, &tripResp.PlaceDetails[idx], cachePlaceDetails)


### PR DESCRIPTION
## Description
When users are navigated back to the search page, they will still see the location input unchanged since we persist this in session storage. However when users attempt to search again without changing the input, they will see the error message `location format must be city, region, country or city, country`. This is cause by `precise-location-flag` being reset to `false` upon loading the page.

## Solution
* Persist `precise-location-flag` value in session storage
* Load the persisted value upon page loading
* Reset `precise-location-flag` value when user intentionally changes input

## Testing
- [ ] Integration testing on Heroku staging
- [ ] Added new unit tests

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
