### PR TITLE
Feat: Nearby cities search [backend only]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/weihesdlegend/Vacation-planner
 
-go 1.18
+go 1.19
 
 require (
 	github.com/alicebob/miniredis/v2 v2.13.3
@@ -17,6 +17,7 @@ require (
 	github.com/sendgrid/sendgrid-go v3.11.1+incompatible
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.6.1
+	github.com/timwangmusic/go-geonames v0.1.1
 	github.com/vmihailenco/msgpack v4.0.4+incompatible
 	github.com/yourbasic/radix v0.0.0-20180308122924-cbe1cc82e907
 	go.uber.org/zap v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -135,6 +135,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/timwangmusic/go-geonames v0.1.1 h1:X2yFJQeLwFSeTDuEBbBTLRXNiZsLe1LSK/VknDL7osA=
+github.com/timwangmusic/go-geonames v0.1.1/go.mod h1:MItrB+GU8FMjydRbg9R5jIlpOGmvNr6hmevhgxViAxM=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs=
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=

--- a/iowrappers/cities.go
+++ b/iowrappers/cities.go
@@ -1,0 +1,12 @@
+package iowrappers
+
+type City struct {
+	ID         string  `json:"id"`
+	GeonameID  int64   `json:"geonameId"`
+	Name       string  `json:"name"`
+	Latitude   float64 `json:"lat"`
+	Longitude  float64 `json:"lng"`
+	Population int64   `json:"population"`
+	AdminArea1 string  `json:"adminArea1"`
+	Country    string  `json:"country"`
+}

--- a/iowrappers/redis_client.go
+++ b/iowrappers/redis_client.go
@@ -30,6 +30,9 @@ const (
 	NumVisitorsPrefix              = "visitor_count"
 	TravelPlansRedisCacheKeyPrefix = "travel_plans"
 	TravelPlanRedisCacheKeyPrefix  = "travel_plan"
+	CityRedisKeyPrefix             = "city"
+	CitiesRedisKey                 = "known_cities_ids"
+	KnownCitiesHashMapRedisKey     = "known_cities_name_to_id"
 )
 
 var RedisClientDefaultBlankContext context.Context
@@ -181,6 +184,107 @@ func (r *RedisClient) SetPlacesAddGeoLocations(c context.Context, places []POI.P
 		}(place)
 	}
 	wg.Wait()
+}
+
+func (r *RedisClient) updateCity(ctx context.Context, city *City) error {
+	key := strings.Join([]string{CityRedisKeyPrefix, city.ID}, ":")
+	json_, err := json.Marshal(city)
+	if err != nil {
+		return err
+	}
+
+	if err = r.Get().Set(ctx, key, json_, 0).Err(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *RedisClient) AddCities(ctx context.Context, cities []City) error {
+	wg := sync.WaitGroup{}
+	wg.Add(len(cities))
+	var err error
+	for _, city := range cities {
+		go func(city City) {
+			defer wg.Done()
+			_, err = r.Get().Pipelined(ctx, func(pipe redis.Pipeliner) error {
+				hashKey := strings.Join([]string{city.Name, city.AdminArea1, city.Country}, "_")
+				var existedCityId string
+				existedCityId, err = r.Get().HGet(ctx, KnownCitiesHashMapRedisKey, hashKey).Result()
+				if err == nil && existedCityId != "" {
+					city.ID = existedCityId
+					return r.updateCity(ctx, &city)
+				}
+
+				err = pipe.HSet(ctx, KnownCitiesHashMapRedisKey, hashKey, city.ID).Err()
+				if err != nil {
+					Logger.Debugf("error adding city %s to %s: %v", city.Name, KnownCitiesHashMapRedisKey, err)
+				}
+
+				key := strings.Join([]string{CityRedisKeyPrefix, city.ID}, ":")
+				var json_ []byte
+				json_, err = json.Marshal(city)
+				if err != nil {
+					return err
+				}
+				if err = pipe.Set(ctx, key, json_, 0).Err(); err != nil {
+					return err
+				}
+
+				if err = pipe.GeoAdd(ctx, CitiesRedisKey, &redis.GeoLocation{
+					Name:      city.ID,
+					Longitude: city.Longitude,
+					Latitude:  city.Latitude,
+				}).Err(); err != nil {
+					return err
+				}
+				Logger.Debugf("added city %s to Redis with key: %s", city.Name, key)
+				return nil
+			})
+			if err != nil {
+				Logger.Error(err)
+			}
+		}(city)
+	}
+	wg.Wait()
+	return err
+}
+
+func (r *RedisClient) NearbyCities(ctx context.Context, lat, lng, radius float64) ([]City, error) {
+	cities, err := r.Get().GeoRadius(ctx, CitiesRedisKey, lng, lat, &redis.GeoRadiusQuery{
+		Radius: radius,
+		Unit:   "km",
+		Sort:   "ASC",
+	}).Result()
+	if err != nil {
+		return nil, err
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(len(cities))
+	// pre-allocate memory for concurrency safety
+	nearbyCities := make([]City, len(cities))
+	for idx, city := range cities {
+		go func(city redis.GeoLocation, idx int) {
+			defer wg.Done()
+
+			cityKey := strings.Join([]string{CityRedisKeyPrefix, city.Name}, ":")
+			cityString, cityQueryErr := r.Get().Get(ctx, cityKey).Result()
+			if cityQueryErr != nil {
+				Logger.Error(cityQueryErr)
+				return
+			}
+
+			unmarshallErr := json.Unmarshal([]byte(cityString), &nearbyCities[idx])
+			if unmarshallErr != nil {
+				Logger.Error(unmarshallErr)
+				return
+			}
+			Logger.Debugf("retrieved city %+v from Redis", nearbyCities[idx])
+		}(city, idx)
+	}
+	wg.Wait()
+	return nearbyCities, nil
 }
 
 // obtain place info from Redis based with key place_details:place_ID:placeID

--- a/iowrappers/transformers.go
+++ b/iowrappers/transformers.go
@@ -1,8 +1,11 @@
 package iowrappers
 
 import (
+	"github.com/google/uuid"
+	go_geonames "github.com/timwangmusic/go-geonames"
 	"github.com/weihesdlegend/Vacation-planner/user"
 	"googlemaps.github.io/maps"
+	"strconv"
 )
 
 func geocodingResultsToGeocodeQuery(query *GeocodeQuery, results []maps.GeocodingResult) {
@@ -32,4 +35,27 @@ func toRedisUserData(view *user.View) map[string]interface{} {
 		"favorites":     view.Favorites,
 		"lastLoginTime": view.LastLoginTime,
 	}
+}
+
+func toCity(city go_geonames.City) (City, error) {
+	lat, err := strconv.ParseFloat(city.Latitude, 64)
+	if err != nil {
+		return City{}, err
+	}
+
+	lng, err := strconv.ParseFloat(city.Longitude, 64)
+	if err != nil {
+		return City{}, err
+	}
+
+	return City{
+		ID:         uuid.New().String(),
+		Name:       city.Name,
+		GeonameID:  city.ID,
+		Latitude:   lat,
+		Longitude:  lng,
+		Population: city.Population,
+		AdminArea1: city.AdminArea1,
+		Country:    city.Country,
+	}, nil
 }

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -695,6 +695,18 @@ func (p *MyPlanner) resetPasswordHandler(ctx *gin.Context) {
 	}
 }
 
+func (p *MyPlanner) getNearbyCities(ctx *gin.Context) {
+	req := &iowrappers.NearbyCityRequest{}
+	if err := ctx.ShouldBindJSON(req); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	}
+	resp, err := p.Solver.Searcher.NearbyCities(ctx, req)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+	}
+	ctx.JSON(http.StatusOK, gin.H{"cities": resp.Cities})
+}
+
 func (p *MyPlanner) SetupRouter(serverPort string) *http.Server {
 	gin.SetMode(gin.ReleaseMode)
 	if p.Environment == "debug" {
@@ -734,6 +746,7 @@ func (p *MyPlanner) SetupRouter(serverPort string) *http.Server {
 		v1.GET("/forgot-password", p.forgotPasswordPage)
 		v1.GET("/reset-password", p.resetPasswordPage)
 		v1.GET("/send-password-reset-email", p.resetPasswordHandler)
+		v1.POST("/nearby-cities", p.getNearbyCities)
 		migrations := v1.Group("/migrate")
 		{
 			migrations.GET("/user-ratings-total", p.UserRatingsTotalMigrationHandler)

--- a/test/redis_client_mocks/nearby_cities_search_test.go
+++ b/test/redis_client_mocks/nearby_cities_search_test.go
@@ -1,0 +1,98 @@
+package redis_client_mocks
+
+import (
+	log "github.com/sirupsen/logrus"
+	"github.com/weihesdlegend/Vacation-planner/iowrappers"
+	"reflect"
+	"testing"
+)
+
+var expectedCities = []iowrappers.City{
+	{
+		ID:         "5376803",
+		GeonameID:  5376803,
+		Name:       "Newark",
+		Latitude:   37.52966,
+		Longitude:  -122.0402,
+		Population: 45000,
+		AdminArea1: "CA",
+		Country:    "United States",
+	},
+	{
+		ID:         "5350734",
+		GeonameID:  5350734,
+		Name:       "Fremont",
+		Latitude:   37.54827,
+		Longitude:  -121.9886,
+		Population: 101900,
+		AdminArea1: "CA",
+		Country:    "United States",
+	},
+	{
+		ID:         "5267812",
+		GeonameID:  5267812,
+		Name:       "Union City",
+		Latitude:   37.5934,
+		Longitude:  -122.0439,
+		AdminArea1: "CA",
+		Country:    "United States",
+	},
+}
+
+func init() {
+	if err := RedisClient.AddCities(RedisContext, expectedCities); err != nil {
+		log.Error(err)
+	}
+}
+
+func TestNearbyCitiesSearch_shouldReturnNearbyCities(t *testing.T) {
+	var err error
+
+	var resultCities []iowrappers.City
+	// simulates a search request from Palo Alto, CA
+	if resultCities, err = RedisClient.NearbyCities(RedisContext, 37.4223, -122.1329, 25.0); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(resultCities) != len(expectedCities) {
+		t.Fatalf("expected number of city returned equals %d, got %d", len(expectedCities), len(resultCities))
+	}
+
+	for idx, city := range resultCities {
+		if !reflect.DeepEqual(city, expectedCities[idx]) {
+			t.Errorf("expected city %s with ID %s, got %s with ID %s", expectedCities[idx].Name, expectedCities[idx].ID, city.Name, city.ID)
+		}
+	}
+}
+
+func TestAddingKnownCities_shouldUpdateRedisRecords(t *testing.T) {
+	var err error
+	var newCities = []iowrappers.City{
+		{
+			ID:         "5350734",
+			GeonameID:  5350734,
+			Name:       "Fremont",
+			Latitude:   37.54827,
+			Longitude:  -121.9886,
+			Population: 151490,
+			AdminArea1: "CA",
+			Country:    "United States",
+		},
+	}
+
+	var resultCities []iowrappers.City
+
+	if err = RedisClient.AddCities(RedisContext, newCities); err != nil {
+		t.Fatal(err)
+	}
+
+	resultCities, err = RedisClient.NearbyCities(RedisContext, 37.4223, -122.1329, 25.0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fremont := resultCities[1]
+	if fremont.Population != newCities[0].Population {
+		t.Errorf("expected population of Fremont to be updated to %d, got %d", newCities[0].Population, fremont.Population)
+	}
+}


### PR DESCRIPTION
## Description
In this change, we integrate a new service provider: [Geonames web provider](https://www.geonames.org/export/web-services.html) through a customized client. The services provide look ups for nearby cities given a location. This helps when our service recommends nearby cities for users to explore.

## Solution
* Fetch nearby cities with Geonames web services.
* Persist nearby cities in Redis to avoid excessive API calls.
* Updates city details when demographic info changes.

## Testing
- [x] Integration testing on Heroku staging
- [x] Added new unit tests

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
