### PR TITLE
Fix: developers can create users in DEVELOPMENT env

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ People typically rely on electronic maps and online resources to plan their trip
 Querying for different routes are tedious at best, and often times it is hard to remember which sources and destinations have been researched.
 When taking in time and financial constraints, this manual planning process quickly becomes mind-boggling.
 * Our goal is to provide a service for travellers to plan for their ideal vacations under financial or time budget.
-* The planning APIs let users to enter travel destination (POI), date and how they would like to divide the day into slots, and the service provides travel plans for the user.
+* The planning APIs let users enter travel destination (POI), date and how they would like to divide the day into slots, and the service provides travel plans for the user.
 * The initial version only plans for single-day trips, and it ranks results without personal preferences.
 
 ## Features
@@ -28,6 +28,7 @@ When taking in time and financial constraints, this manual planning process quic
 ## Development
 * Obtain Google Maps API key and set the `MAPS_CLIENT_API_KEY=YOUR_GCP_API_KEY`,
 `REDISCLOUD_URL=redis://localhost:6379` environment variables
+* Set environment variable `ENVIRONMENT=DEVELOPMENT,SENDGRID_API_KEY=NO_KEY` as we do not create mailers in development environment.
 * Start (in background) Redis service with `brew services start redis`
 * Execute `go run main/main.go` to start the server
 

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -159,9 +159,11 @@ func (p *MyPlanner) Init(mapsClientApiKey string, redisURL *url.URL, redisStream
 		Scopes:       []string{"https://www.googleapis.com/auth/userinfo.email"},
 		Endpoint:     google.Endpoint,
 	}
-	p.Mailer = &iowrappers.Mailer{}
-	if err = p.Mailer.Init(p.RedisClient); err != nil {
-		log.Fatalf("p failed to create a Mailer: %s", err.Error())
+	if p.Environment == ProductionEnvironment || p.Environment == TestingEnvironment {
+		p.Mailer = &iowrappers.Mailer{}
+		if err = p.Mailer.Init(p.RedisClient); err != nil {
+			log.Fatalf("p failed to create a Mailer: %s", err.Error())
+		}
 	}
 }
 
@@ -704,7 +706,7 @@ func (p *MyPlanner) resetPasswordHandler(ctx *gin.Context) {
 		ctx.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("no user is found with email %s", email)})
 	}
 
-	if err = p.Mailer.Send(ctx, iowrappers.PasswordReset, view, string(p.Environment)); err != nil {
+	if err = p.Mailer.Send(ctx, iowrappers.PasswordReset, view, strings.ToLower(string(p.Environment))); err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 	}
 }


### PR DESCRIPTION
## Description
Developers cannot create new users in `DEVELOPMENT` environment. This change addresses this issue.

## Solution
* Do not validate user emails in `DEVELOPMENT` environment.

## Testing
- [x] Integration testing on Heroku staging
- [ ] Added new unit tests

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
