### PR TITLE
Fix: discard erroneous city retrieval results from Redis

### DIFF
--- a/test/redis_client_mocks/nearby_cities_search_test.go
+++ b/test/redis_client_mocks/nearby_cities_search_test.go
@@ -4,17 +4,17 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/weihesdlegend/Vacation-planner/iowrappers"
 	"reflect"
+	"sort"
 	"testing"
 )
 
 var expectedCities = []iowrappers.City{
 	{
-		ID:         "5376803",
-		GeonameID:  5376803,
-		Name:       "Newark",
-		Latitude:   37.52966,
-		Longitude:  -122.0402,
-		Population: 45000,
+		ID:         "5267812",
+		GeonameID:  5267812,
+		Name:       "Union City",
+		Latitude:   37.5934,
+		Longitude:  -122.0439,
 		AdminArea1: "CA",
 		Country:    "United States",
 	},
@@ -29,11 +29,12 @@ var expectedCities = []iowrappers.City{
 		Country:    "United States",
 	},
 	{
-		ID:         "5267812",
-		GeonameID:  5267812,
-		Name:       "Union City",
-		Latitude:   37.5934,
-		Longitude:  -122.0439,
+		ID:         "5376803",
+		GeonameID:  5376803,
+		Name:       "Newark",
+		Latitude:   37.52966,
+		Longitude:  -122.0402,
+		Population: 45000,
 		AdminArea1: "CA",
 		Country:    "United States",
 	},
@@ -57,6 +58,10 @@ func TestNearbyCitiesSearch_shouldReturnNearbyCities(t *testing.T) {
 	if len(resultCities) != len(expectedCities) {
 		t.Fatalf("expected number of city returned equals %d, got %d", len(expectedCities), len(resultCities))
 	}
+
+	sort.Slice(resultCities, func(i, j int) bool {
+		return resultCities[i].ID < resultCities[j].ID
+	})
 
 	for idx, city := range resultCities {
 		if !reflect.DeepEqual(city, expectedCities[idx]) {
@@ -90,6 +95,10 @@ func TestAddingKnownCities_shouldUpdateRedisRecords(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	sort.Slice(resultCities, func(i, j int) bool {
+		return resultCities[i].ID < resultCities[j].ID
+	})
 
 	fremont := resultCities[1]
 	if fremont.Population != newCities[0].Population {


### PR DESCRIPTION
## Description
When Redis clients fail to retrieve city details, the entry in the slice is empty and the client has to filter it out.

## Solution
* Only pushes valid city details to the result slice.
* Workers send results to a channel for the main Go routine to collect.

## Testing
- [ ] Integration testing on Heroku staging
- [x] Added new unit tests

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
