### PR TITLE
Generics: make min priority queue generic

### DIFF
--- a/planner/min_priority_queue.go
+++ b/planner/min_priority_queue.go
@@ -1,27 +1,29 @@
 package planner
 
-type MinPriorityQueue []Vertex
-
-func (pq *MinPriorityQueue) Len() int {
-	return len(*pq)
+type MinPriorityQueue[T PriorityQueueItem] struct {
+	items []T
 }
 
-func (pq *MinPriorityQueue) Less(i, j int) bool {
-	return (*pq)[i].Key <= (*pq)[j].Key
+func (pq *MinPriorityQueue[T]) Len() int {
+	return len(pq.items)
 }
 
-func (pq *MinPriorityQueue) Swap(i, j int) {
-	(*pq)[i], (*pq)[j] = (*pq)[j], (*pq)[i]
+func (pq *MinPriorityQueue[T]) Less(i, j int) bool {
+	return pq.items[i].Key() <= pq.items[j].Key()
 }
 
-func (pq *MinPriorityQueue) Push(item interface{}) {
-	*pq = append(*pq, item.(Vertex))
+func (pq *MinPriorityQueue[T]) Swap(i, j int) {
+	pq.items[i], pq.items[j] = pq.items[j], pq.items[i]
 }
 
-func (pq *MinPriorityQueue) Pop() interface{} {
-	prev := *pq
+func (pq *MinPriorityQueue[T]) Push(item interface{}) {
+	pq.items = append(pq.items, item.(T))
+}
+
+func (pq *MinPriorityQueue[T]) Pop() interface{} {
+	prev := pq.items
 	n := len(prev)
 	res := prev[n-1]
-	*pq = prev[0 : n-1]
+	pq.items = prev[0 : n-1]
 	return res
 }

--- a/planner/min_priority_queue_vertex_test.go
+++ b/planner/min_priority_queue_vertex_test.go
@@ -6,13 +6,13 @@ import (
 )
 
 func TestMinPriorityQueue(t *testing.T) {
-	pq := &MinPriorityQueue{}
+	pq := &MinPriorityQueue[Vertex]{}
 
-	nyc := Vertex{Key: 5.5, Name: "New York"}
-	la := Vertex{Key: 4.4, Name: "Los Angeles"}
-	lv := Vertex{Key: 3.3, Name: "Las Vegas"}
-	pitt := Vertex{Key: 2.2, Name: "Pittsburgh"}
-	boston := Vertex{Key: 1.1, Name: "Boston"}
+	nyc := Vertex{K: 5.5, Name: "New York"}
+	la := Vertex{K: 4.4, Name: "Los Angeles"}
+	lv := Vertex{K: 3.3, Name: "Las Vegas"}
+	pitt := Vertex{K: 2.2, Name: "Pittsburgh"}
+	boston := Vertex{K: 1.1, Name: "Boston"}
 
 	cities := []Vertex{pitt, lv, nyc, boston, la}
 

--- a/planner/solver.go
+++ b/planner/solver.go
@@ -264,7 +264,7 @@ func FindBestPlanningSolutions(ctx context.Context, placeClusters [][]matching.P
 		topSolutionsCount = TopSolutionsCountDefault
 	}
 
-	priorityQueue := &MinPriorityQueue{}
+	priorityQueue := &MinPriorityQueue[Vertex]{}
 	deduplicatedPlans := make(map[string]bool)
 	resp = make(chan PlanningResp, 1)
 
@@ -285,10 +285,10 @@ func FindBestPlanningSolutions(ctx context.Context, placeClusters [][]matching.P
 			if !isDuplicatedPlan(deduplicatedPlans, candidate) {
 				continue
 			}
-			newVertex := Vertex{Name: candidate.ID, Key: candidate.Score, Object: candidate}
+			newVertex := Vertex{Name: candidate.ID, K: candidate.Score, Object: candidate}
 			if priorityQueue.Len() == topSolutionsCount {
-				topVertex := (*priorityQueue)[0]
-				if topVertex.Key < newVertex.Key {
+				topVertex := priorityQueue.items[0]
+				if topVertex.Key() < newVertex.Key() {
 					heap.Pop(priorityQueue)
 					delete(deduplicatedPlans, jointPlaceIdsForPlan(topVertex.Object.(PlanningSolution)))
 					heap.Push(priorityQueue, newVertex)

--- a/planner/vertex.go
+++ b/planner/vertex.go
@@ -1,7 +1,15 @@
 package planner
 
+type PriorityQueueItem interface {
+	Key() float64
+}
+
 type Vertex struct {
-	Key    float64 // vertex key
+	K      float64 // key or priority
 	Name   string  // vertex name
 	Object interface{}
+}
+
+func (v Vertex) Key() float64 {
+	return v.K
 }


### PR DESCRIPTION
## Description
Make min priority queue generic. Priority queues in the planner repository should not be limited to holding items of `Vertex` type.

## Solution
* Define a `PriorityQueueItem` interface and make the `Vertex` type implement it.
* Refactor `MinPriorityQueue` to holding items of generic type of `PriorityQueueItem`.

## Testing
- [x] Integration testing on Heroku staging
- [ ] Added new unit tests

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
