### PR TITLE
Allow one place to appear multiple times in the search result page

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -6,3 +6,5 @@ server:
       - formatted_address
       - adr_address
       - url
+  plan_solver:
+    SamePlaceDupCountLimit: 2

--- a/planner/solver.go
+++ b/planner/solver.go
@@ -264,6 +264,7 @@ func FindBestPlanningSolutions(ctx context.Context, placeClusters [][]matching.P
 	}
 
 	priorityQueue := &MinPriorityQueue[Vertex]{}
+	// int8 is enough for a the place deduplication limit
 	includedPlaces := make(map[string]int8)
 	resp = make(chan PlanningResp, 1)
 


### PR DESCRIPTION
## Description
Improve the quality of plan recommendation page, so that the same location may appear in multiple suggested plan trip candidates. Currently, the same place is only allowed to appear once, and this may limit the number of suggested plans for certain cities.

For example, Q pop shop appears twice in the result plan list.
![Screenshot 2023-09-09 at 3 24 55 PM](https://github.com/timwangmusic/Vacation-Planner/assets/54508739/3fe4cf3b-dbc3-4623-9810-c62a7b0a819d)


## Solution
* Add a counter for each place during the main search/solver algorithm
* The counter can be implemented by a hashMap 
* In future PR, we can add this as a configurable param with some refactor on solver.go  

## Testing
- [x] Integration testing on Heroku staging
- [ ] Added new unit tests

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
