### PR TITLE
Fix: add user_ratings_total to details search fields list

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -6,3 +6,4 @@ server:
       - formatted_address
       - adr_address
       - url
+      - user_ratings_total


### PR DESCRIPTION
## Description
We are missing `user_ratings_total` field in Google Maps requests, even though we are using this in calculating scores.

## Solution
* Add this field in `config/config.yaml`.

## Testing
- [ ] Integration testing on Heroku staging
- [ ] Added new unit tests

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
