### PR TITLE
Update Place freshness logic

### DIFF
--- a/iowrappers/nearby_search.go
+++ b/iowrappers/nearby_search.go
@@ -164,6 +164,7 @@ func (c *MapsClient) extensiveNearbySearch(ctx context.Context, maxRequestTimes 
 		"Maps API call time", searchDuration,
 		"center location (lat,lng)", request.Location,
 		"place category", request.PlaceCat,
+		"price level", request.PriceLevel,
 		"total results", totalResult,
 	)
 	done <- true

--- a/iowrappers/redis_client.go
+++ b/iowrappers/redis_client.go
@@ -36,6 +36,7 @@ const (
 	CityRedisKeyPrefix             = "city"
 	CitiesRedisKey                 = "known_cities_ids"
 	KnownCitiesHashMapRedisKey     = "known_cities_name_to_id"
+	MapsLastSearchTimeRedisKey     = "MapsLastSearchTime"
 )
 
 var RedisClientDefaultBlankContext context.Context
@@ -109,11 +110,9 @@ func (r *RedisClient) setPlace(context context.Context, place POI.Place, wg *syn
 	}
 }
 
-func (r *RedisClient) GetMapsLastSearchTime(context context.Context, location POI.Location, category POI.PlaceCategory) (lastSearchTime time.Time, err error) {
-	redisKey := "MapsLastSearchTime"
-
-	redisField := strings.ToLower(strings.Join([]string{location.Country, location.City, string(category)}, ":"))
-	lst, cacheErr := r.client.HGet(context, redisKey, redisField).Result()
+func (r *RedisClient) GetMapsLastSearchTime(context context.Context, location POI.Location, category POI.PlaceCategory, priceLevel POI.PriceLevel) (lastSearchTime time.Time, err error) {
+	redisField := strings.ToLower(strings.Join([]string{location.Country, location.AdminAreaLevelOne, location.City, string(category), strconv.Itoa(int(priceLevel))}, ":"))
+	lst, cacheErr := r.client.HGet(context, MapsLastSearchTimeRedisKey, redisField).Result()
 	if cacheErr != nil {
 		err = cacheErr
 		return
@@ -127,10 +126,9 @@ func (r *RedisClient) GetMapsLastSearchTime(context context.Context, location PO
 	return
 }
 
-func (r *RedisClient) SetMapsLastSearchTime(context context.Context, location POI.Location, category POI.PlaceCategory, requestTime string) (err error) {
-	redisKey := "MapsLastSearchTime"
-	redisField := strings.ToLower(strings.Join([]string{location.Country, location.City, string(category)}, ":"))
-	_, err = r.client.HSet(context, redisKey, redisField, requestTime).Result()
+func (r *RedisClient) SetMapsLastSearchTime(context context.Context, location POI.Location, category POI.PlaceCategory, priceLevel POI.PriceLevel, requestTime string) (err error) {
+	redisField := strings.ToLower(strings.Join([]string{location.Country, location.AdminAreaLevelOne, location.City, string(category), strconv.Itoa(int(priceLevel))}, ":"))
+	_, err = r.client.HSet(context, MapsLastSearchTimeRedisKey, redisField, requestTime).Result()
 	return
 }
 

--- a/planner/solver.go
+++ b/planner/solver.go
@@ -262,8 +262,8 @@ func FindBestPlanningSolutions(ctx context.Context, placeClusters [][]matching.P
 		topSolutionsCount = TopSolutionsCountDefault
 	}
 
-  priorityQueue := &MinPriorityQueue[Vertex]{}
-  includedPlaces := make(map[string]bool)
+	priorityQueue := &MinPriorityQueue[Vertex]{}
+	includedPlaces := make(map[string]bool)
 	resp = make(chan PlanningResp, 1)
 
 	for iterator.HasNext() {

--- a/test/redis_client_mocks/maps_last_search_time_test.go
+++ b/test/redis_client_mocks/maps_last_search_time_test.go
@@ -1,29 +1,56 @@
 package redis_client_mocks
 
 import (
+	"context"
+	"github.com/stretchr/testify/assert"
 	"github.com/weihesdlegend/Vacation-planner/POI"
-	"github.com/weihesdlegend/Vacation-planner/iowrappers"
 	"testing"
 	"time"
 )
 
-func TestMapsLastSearchTime(t *testing.T) {
-	request := iowrappers.PlaceSearchRequest{
-		Location: POI.Location{City: "Beijing", Country: "China"},
-		PlaceCat: "Visit",
+func TestRedisClient_GetMapsLastSearchTime(t *testing.T) {
+	currentTime := time.Now()
+	type args struct {
+		context    context.Context
+		location   POI.Location
+		category   POI.PlaceCategory
+		priceLevel POI.PriceLevel
+		timeToSave time.Time
 	}
+	tests := []struct {
+		name               string
+		args               args
+		wantLastSearchTime time.Time
+		wantErr            bool
+	}{
+		{
+			name: "Redis client should retrieve Maps last search time",
+			args: args{
+				context:    context.Background(),
+				location:   POI.Location{City: "San Francisco", AdminAreaLevelOne: "CA", Country: "USA"},
+				category:   POI.PlaceCategoryEatery,
+				priceLevel: POI.PriceLevelFour,
+				timeToSave: currentTime,
+			},
+			wantLastSearchTime: currentTime,
+			wantErr:            false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := RedisClient
+			err := r.SetMapsLastSearchTime(tt.args.context, tt.args.location, tt.args.category, tt.args.priceLevel, tt.args.timeToSave.Format(time.RFC3339))
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	currentTime := time.Now().Format(time.RFC3339)
-	_ = RedisClient.SetMapsLastSearchTime(RedisContext, request.Location, request.PlaceCat, currentTime)
+			gotLastSearchTime, err := r.GetMapsLastSearchTime(tt.args.context, tt.args.location, tt.args.category, tt.args.priceLevel)
+			if !tt.wantErr && err != nil {
+				t.Errorf("GetMapsLastSearchTime(%v, %v, %v, %v) encountered error: %v", tt.args.context, tt.args.location, tt.args.category, tt.args.priceLevel, err)
+				return
+			}
 
-	cachedTime, err := RedisClient.GetMapsLastSearchTime(RedisContext, request.Location, request.PlaceCat)
-
-	if err != nil || currentTime != cachedTime.Format(time.RFC3339) {
-		t.Error("maps cached time retrieval failure")
-		if err != nil {
-			t.Error(err)
-		} else {
-			t.Errorf("expected cached time %s, got %s", currentTime, cachedTime.Format(time.RFC3339))
-		}
+			assert.Equalf(t, tt.wantLastSearchTime.Format(time.RFC3339), gotLastSearchTime.Format(time.RFC3339), "GetMapsLastSearchTime(%v, %v, %v, %v)", tt.args.context, tt.args.location, tt.args.category, tt.args.priceLevel)
+		})
 	}
 }


### PR DESCRIPTION
## Description
Previously, we determine if a new API call to the Maps is necessary when the number of results is lower than requested. However, with the new Maps query fixed on min/max price level, this will not work properly since higher priced restaurants are inevitably less than the requested most of the time. Therefore the new logic says as long as we have some data for the location with the requested category and price level, it is acceptable data from the database.

## Solution
* `MapsSearchTime` entries have `PriceLevel` info now
* Update place freshness if statement

## Testing
- [ ] Integration testing on Heroku staging
- [x] Added new unit tests

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
