### PR TITLE
Add a filter to remove places with zero user rating count

### DIFF
--- a/iowrappers/poi_searcher.go
+++ b/iowrappers/poi_searcher.go
@@ -226,7 +226,7 @@ func (s *PoiSearcher) searchPlacesWithMaps(ctx context.Context, req *PlaceSearch
 
 	if req.BusinessStatus == POI.Operational {
 		totalPlacesCount := len(places)
-		places = filter(places, func(place POI.Place) bool { return place.Status == POI.Operational })
+		places = Filter(places, func(place POI.Place) bool { return place.Status == POI.Operational })
 		Logger.Debugf("%d places out of %d left after business status filtering", len(places), totalPlacesCount)
 	}
 

--- a/iowrappers/redis_client.go
+++ b/iowrappers/redis_client.go
@@ -8,13 +8,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/bobg/go-generics/slices"
-	gogeonames "github.com/timwangmusic/go-geonames"
 	"net/url"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/bobg/go-generics/slices"
+	gogeonames "github.com/timwangmusic/go-geonames"
 
 	"github.com/redis/go-redis/v9"
 	log "github.com/sirupsen/logrus"
@@ -361,7 +362,7 @@ func (r *RedisClient) NearbySearch(ctx context.Context, req *PlaceSearchRequest)
 
 	if req.BusinessStatus == POI.Operational {
 		totalPlacesCount := len(places)
-		places = filter(places, func(place POI.Place) bool { return place.Status == POI.Operational })
+		places = Filter(places, func(place POI.Place) bool { return place.Status == POI.Operational })
 		Logger.Debugf("(RedisClient)NearbySearch -> %d places out of %d left after business status filtering", len(places), totalPlacesCount)
 	}
 	return places, nil

--- a/iowrappers/utils.go
+++ b/iowrappers/utils.go
@@ -3,10 +3,10 @@ package iowrappers
 import (
 	"context"
 	"errors"
-	"github.com/modern-go/reflect2"
-	"github.com/weihesdlegend/Vacation-planner/POI"
-	"github.com/weihesdlegend/Vacation-planner/user"
 	"sync"
+
+	"github.com/modern-go/reflect2"
+	"github.com/weihesdlegend/Vacation-planner/user"
 )
 
 func scanRedisKeys(context context.Context, redisClient *RedisClient, redisKeyPrefix string) ([]string, error) {
@@ -33,9 +33,9 @@ func scanRedisKeys(context context.Context, redisClient *RedisClient, redisKeyPr
 	return redisKeys, nil
 }
 
-// a generic filtering function for places
-func filter(places []POI.Place, condition func(place POI.Place) bool) []POI.Place {
-	var results []POI.Place
+// Filter places that meet certain condition
+func Filter[T any](places []T, condition func(place T) bool) []T {
+	var results []T
 	for _, place := range places {
 		if condition(place) {
 			results = append(results, place)

--- a/matching/matcher.go
+++ b/matching/matcher.go
@@ -19,6 +19,7 @@ const (
 	MinResultsForTimePeriodMatching                = 20
 	FilterByTimePeriod              FilterCriteria = "filterByTimePeriod"
 	FilterByPriceRange              FilterCriteria = "filterByPriceRange"
+	FilterByUserRating              FilterCriteria = "filterByUserRating"
 )
 
 type Request struct {
@@ -130,4 +131,36 @@ func filterPlacesOnPriceLevel(places []Place, level POI.PriceLevel) []Place {
 		}
 	}
 	return results
+}
+
+// Filter parameters related with user rating
+type UserRatingFilterParams struct {
+	MinUserRatings int
+}
+
+// Filter to remove low user rating
+type FilterLowUserRating struct {
+}
+
+// Implement Match from the `Matcher` interface
+func (m FilterLowUserRating) Match(req *FilterRequest) ([]Place, error) {
+	var results []Place
+	filterParams := req.Params[req.Criteria]
+
+	if _, ok := filterParams.(UserRatingFilterParams); !ok {
+		return results, errors.New("user rating matcher received wrong filter params")
+	}
+	params := filterParams.(UserRatingFilterParams)
+	return filterUserRating(req.Places, params.MinUserRatings), nil
+}
+
+func filterUserRating(places []Place, minUserRating int) []Place {
+	var output = make([]Place, 0, len(places))
+	for _, place := range places {
+		if place.UserRatingsCount() < minUserRating {
+			continue
+		}
+		output = append(output, place)
+	}
+	return output
 }

--- a/planner/solver.go
+++ b/planner/solver.go
@@ -46,12 +46,12 @@ func (ps PlanningSolution) Key() float64 {
 }
 
 type Solver struct {
-	Searcher               *iowrappers.PoiSearcher
-	UserRatingMatcher      matching.Matcher
-	TimeMatcher            matching.Matcher
-	PriceRangeMatcher      matching.Matcher
-	placeDedupeCountLimit  int
-	nearbyCitiesCountLimit int
+	Searcher                *iowrappers.PoiSearcher
+	UserRatingsCountMatcher matching.Matcher
+	TimeMatcher             matching.Matcher
+	PriceRangeMatcher       matching.Matcher
+	placeDedupeCountLimit   int
+	nearbyCitiesCountLimit  int
 }
 
 const (
@@ -101,7 +101,7 @@ type SlotRequest struct {
 
 func (s *Solver) Init(poiSearcher *iowrappers.PoiSearcher, placeDedupeCountLimit int, nearbyCitiesCountLimit int) {
 	s.Searcher = poiSearcher
-	s.UserRatingMatcher = matching.FilterLowUserRating{}
+	s.UserRatingsCountMatcher = matching.MatcherForUserRatings{}
 	s.TimeMatcher = matching.MatcherForTime{Searcher: poiSearcher}
 	s.PriceRangeMatcher = matching.MatcherForPriceRange{Searcher: poiSearcher}
 	s.placeDedupeCountLimit = placeDedupeCountLimit
@@ -499,7 +499,7 @@ func (s *Solver) generatePlacesForSlots(ctx context.Context, req *PlanningReques
 		}
 		logger.Debugf("Before filtering, the number of places for category %s is %d", slot.Category, len(places))
 
-		placesByRating, err := s.UserRatingMatcher.Match(&matching.FilterRequest{
+		placesByRating, err := s.UserRatingsCountMatcher.Match(&matching.FilterRequest{
 			Places:   places,
 			Criteria: matching.FilterByUserRating,
 			Params:   filterParams,

--- a/planner/solver.go
+++ b/planner/solver.go
@@ -465,6 +465,18 @@ func (s *Solver) weightMatrix(placeClusters [][]matching.Place) ([]string, [][]i
 	return placeIds, weights, nil
 }
 
+func filterZeroRating(places []matching.Place) []matching.Place {
+	var output = make([]matching.Place, 0, len(places))
+	for _, place := range places {
+		if place.UserRatingsCount() == 0 {
+			continue
+		}
+		output = append(output, place)
+	}
+	return output
+}
+
+// TODO: add a new matcher here to filter out places without user rating
 func (s *Solver) generatePlacesForSlots(ctx context.Context, req *PlanningRequest) ([][]matching.Place, error) {
 	logger := iowrappers.Logger
 	var placeClusters [][]matching.Place
@@ -493,8 +505,11 @@ func (s *Solver) generatePlacesForSlots(ctx context.Context, req *PlanningReques
 		}
 		logger.Debugf("Before filtering, the number of places for category %s is %d", slot.Category, len(places))
 
+		placesHasRatings := filterZeroRating(places)
+		logger.Debugf("Filter out zero user rating, the number of places for category %s is %d", slot.Category, len(placesHasRatings))
+
 		placesByTime, err := s.TimeMatcher.Match(&matching.FilterRequest{
-			Places:   places,
+			Places:   placesHasRatings,
 			Criteria: matching.FilterByTimePeriod,
 			Params:   filterParams,
 		})


### PR DESCRIPTION
## Description
Some places in the top results may have broken photo URL. Most of them don't have any user rating count from Google Map API. This is related with issue #310

## Solution
* Add a filter to remove places with zero user rating count
* Tested locally with debug print messages, do show zero user rating places are gone.
* Plan to follow the matcher style as time and price matchers.
![Screenshot 2023-09-21 at 9 44 23 PM](https://github.com/timwangmusic/Vacation-Planner/assets/54508739/fd0c6e7b-9b99-4b1d-b21e-bdedb39203f5)

## Testing
- [x] Integration testing on Heroku staging
- [ ] Added new unit tests

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
