### PR TITLE
Migrations: User ratings count data migrations

### DIFF
--- a/iowrappers/data_migrations.go
+++ b/iowrappers/data_migrations.go
@@ -72,6 +72,7 @@ func (r *RedisClient) removePlace(context context.Context, placeRedisKey string,
 		return nil
 	}
 
+	Logger.Debugf("removing place %+v from Redis", place)
 	*count++
 	// remove keys from all categorized sorted lists in case a place belongs to multiple categories
 	_, _ = r.client.ZRem(context, "placeIDs:visit", placeID).Result()
@@ -102,7 +103,7 @@ func isPlaceDetailsValid(place POI.Place, nonEmptyFields []PlaceDetailsFields) b
 
 // a generic migration method
 // returns place details results for the calling function to extract and use specific fields
-func (s *PoiSearcher) addDataFieldsToPlaces(context context.Context, field string, batchSize int) (map[string]PlaceDetailSearchResult, error) {
+func (s *PoiSearcher) addDataFieldsToPlaces(context context.Context, field string, batchSize int) (map[string]PlaceDetailsSearchResult, error) {
 	mapsClient := s.GetMapsClient()
 	redisClient := s.GetRedisClient()
 	placeDetailsKeys, totalPlacesCount, err := redisClient.GetPlaceCountInRedis(context)
@@ -128,7 +129,7 @@ func (s *PoiSearcher) addDataFieldsToPlaces(context context.Context, field strin
 	Logger.Infof("[data migration] The number of places need update is %d with target field: %s", len(placesNeedUpdate), field)
 
 	placesToUpdateCount := min(len(placesNeedUpdate), batchSize)
-	newPlaceDetailsResults := make([]PlaceDetailSearchResult, placesToUpdateCount)
+	newPlaceDetailsResults := make([]PlaceDetailsSearchResult, placesToUpdateCount)
 	Logger.Infof("[data migration] Place to update count: %d, batch size is: %d", placesToUpdateCount, batchSize)
 	Logger.Infof("[data migration] Getting %d place details with target field: %s", placesToUpdateCount, field)
 
@@ -143,7 +144,7 @@ func (s *PoiSearcher) addDataFieldsToPlaces(context context.Context, field strin
 	}
 
 	wg.Wait()
-	results := make(map[string]PlaceDetailSearchResult)
+	results := make(map[string]PlaceDetailsSearchResult)
 
 	for idx, placeId := range placesNeedUpdate[:placesToUpdateCount] {
 		results[placeId] = newPlaceDetailsResults[idx]
@@ -170,10 +171,10 @@ func (s *PoiSearcher) AddUserRatingsTotal(context context.Context) error {
 			continue
 		}
 		// FIXME: figure out the reason for maps client return null pointer as result
-		if reflect.ValueOf(detailedResult.Res).IsNil() {
+		if reflect.ValueOf(detailedResult.res).IsNil() {
 			place.SetUserRatingsTotal(0)
 		} else {
-			place.SetUserRatingsTotal(detailedResult.Res.UserRatingsTotal)
+			place.SetUserRatingsTotal(detailedResult.res.UserRatingsTotal)
 		}
 		go redisClient.setPlace(context, place, &wg)
 	}
@@ -196,10 +197,10 @@ func (s *PoiSearcher) AddUrl(context context.Context) error {
 			continue
 		}
 		// FIXME: figure out the reason for maps client return null pointer as result
-		if reflect.ValueOf(detailedResult.Res).IsNil() {
+		if reflect.ValueOf(detailedResult.res).IsNil() {
 			place.SetURL("")
 		} else {
-			place.SetURL(detailedResult.Res.URL)
+			place.SetURL(detailedResult.res.URL)
 		}
 		go redisClient.setPlace(context, place, &wg)
 	}

--- a/iowrappers/data_migrations_test.go
+++ b/iowrappers/data_migrations_test.go
@@ -51,9 +51,26 @@ func TestRemovePlaces(t *testing.T) {
 		},
 	}
 
+	// a place with zero user ratings count
+	placeC := POI.Place{
+		ID:           "33513",
+		Name:         "FT Cafe",
+		LocationType: POI.LocationTypeCafe,
+		PriceLevel:   POI.PriceLevelOne,
+		Location: POI.Location{
+			Latitude:  12.5734,
+			Longitude: 14.7912,
+		},
+		URL: "www.ftcafe.net",
+		Photo: POI.PlacePhoto{
+			Reference: "www.ftcafe.net/photos",
+		},
+		UserRatingsTotal: 0,
+	}
+
 	var places []POI.Place
 	var err error
-	redisClient.SetPlacesAddGeoLocations(ctx, []POI.Place{placeA, placeB})
+	redisClient.SetPlacesAddGeoLocations(ctx, []POI.Place{placeA, placeB, placeC})
 	places, _ = redisClient.NearbySearch(ctx, &PlaceSearchRequest{
 		PlaceCat: POI.PlaceCategoryVisit,
 		Location: POI.Location{
@@ -68,7 +85,7 @@ func TestRemovePlaces(t *testing.T) {
 		return
 	}
 
-	err = redisClient.RemovePlaces(ctx, []PlaceDetailsFields{PlaceDetailsFieldURL, PlaceDetailsFieldPhoto})
+	err = redisClient.RemovePlaces(ctx, []PlaceDetailsFields{PlaceDetailsFieldURL, PlaceDetailsFieldPhoto, PlaceDetailsFieldUserRatingsCount})
 	if err != nil {
 		t.Error(err)
 		return
@@ -84,7 +101,21 @@ func TestRemovePlaces(t *testing.T) {
 	})
 
 	if len(places) != 0 {
-		t.Errorf("expected number of places after removal equals 0, got %d", len(places))
+		t.Errorf("expected number of %s places after removal equals 0, got %d", POI.PlaceCategoryVisit, len(places))
+		return
+	}
+
+	places, _ = redisClient.NearbySearch(ctx, &PlaceSearchRequest{PlaceCat: POI.PlaceCategoryEatery,
+		Location: POI.Location{
+			Latitude:  12.5636,
+			Longitude: 14.7813,
+		},
+		Radius: 10000,
+	},
+	)
+
+	if len(places) != 0 {
+		t.Errorf("expected number of %s places after removal equals 0, got %d", POI.PlaceCategoryEatery, len(places))
 		return
 	}
 }

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -225,7 +225,7 @@ func (p *MyPlanner) removePlacesMigrationHandler(ctx *gin.Context) {
 		ctx.JSON(http.StatusUnauthorized, gin.H{"error": authenticationErr.Error()})
 		return
 	}
-	if err := p.Solver.Searcher.RemovePlaces(ctx, []iowrappers.PlaceDetailsFields{iowrappers.PlaceDetailsFieldURL, iowrappers.PlaceDetailsFieldPhoto}); err != nil {
+	if err := p.Solver.Searcher.RemovePlaces(ctx, []iowrappers.PlaceDetailsFields{iowrappers.PlaceDetailsFieldURL, iowrappers.PlaceDetailsFieldPhoto, iowrappers.PlaceDetailsFieldUserRatingsCount}); err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}


### PR DESCRIPTION
## Description
To improve plan quality, we want to remove places with zero user ratings count from the database.

## Solution
* Add zero user ratings count when cleaning places in Redis.
* Filter places with zero user ratings count when saving places from fresh Maps search results.

## Testing
- [x] Integration testing on Heroku staging
- [x] Added new unit tests

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
