### PR TITLE
Experiement: use a new formula for places price level zero

### DIFF
--- a/matching/score.go
+++ b/matching/score.go
@@ -10,8 +10,7 @@ import (
 )
 
 const (
-	AvgRating  = 3.0
-	AvgPricing = PriceDefaultMean
+	MaxPlaceRating = 5.0
 )
 
 // OLD plan scoring method, use maxDist as the normalisation factor
@@ -43,7 +42,7 @@ func Score(places []Place, distNorm int) float64 {
 func singlePlaceScore(place Place) float64 {
 	var ratingPricingRatio float64
 	if place.PlacePrice() == 0 {
-		ratingPricingRatio = AvgRating / AvgPricing // set to average single Place rating-price ratio
+		ratingPricingRatio = float64(place.Rating()) / MaxPlaceRating
 	} else {
 		ratingPricingRatio = float64(place.Rating()) / place.PlacePrice()
 	}

--- a/matching/score.go
+++ b/matching/score.go
@@ -40,13 +40,13 @@ func Score(places []Place, distNorm int) float64 {
 }
 
 func singlePlaceScore(place Place) float64 {
-	var ratingPricingRatio float64
+	var boostFactor float64
 	if place.PlacePrice() == 0 {
-		ratingPricingRatio = float64(place.Rating()) / MaxPlaceRating
+		boostFactor = float64(place.Rating()) / MaxPlaceRating
 	} else {
-		ratingPricingRatio = float64(place.Rating()) / place.PlacePrice()
+		boostFactor = float64(place.Rating()) / place.PlacePrice()
 	}
-	return math.Log10(float64(1+place.UserRatingsCount())) * ratingPricingRatio
+	return math.Log10(float64(1+place.UserRatingsCount())) * boostFactor
 }
 
 // calculate Haversine distances between places

--- a/test/score_test.go
+++ b/test/score_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,55 +14,26 @@ var testSinglePlaces = []matching.Place{
 		PriceLevel:       POI.PriceLevelThree,
 		Rating:           5.0,
 		UserRatingsTotal: 99,
-	}, POI.PlaceCategoryVisit),
+	}, POI.PlaceCategoryEatery),
 	matching.CreatePlace(POI.Place{
 		PriceLevel:       POI.PriceLevelZero,
 		Rating:           3.0,
-		UserRatingsTotal: 0,
+		UserRatingsTotal: 999,
 	}, POI.PlaceCategoryVisit),
 }
 
-func TestLegacyScoreSinglePlacePlan(t *testing.T) {
-	// test regular non-zero-price place
-	expectedScore := 0.2
-	score := matching.ScoreOld([]matching.Place{testSinglePlaces[0]})
-	if score != expectedScore {
-		t.Errorf("Expected score %f, got %f", expectedScore, score)
-		return
-	}
-
-	// test zero-price place
-	expectedScore = 0.0
-	score = matching.ScoreOld([]matching.Place{testSinglePlaces[1]})
-	if score != expectedScore {
-		t.Errorf("Expected score %f, got %f", expectedScore, score)
-		return
-	}
-}
-
 func TestScoreSinglePlacePlan(t *testing.T) {
-	// place1 := matching.CreatePlace(POI.Place{
-	// 	PriceLevel:       POI.PriceLevelThree,
-	// 	Rating:           5.0,
-	// 	UserRatingsTotal: 99,
-	// }, POI.PlaceCategoryVisit)
-	// place2 := matching.CreatePlace(POI.Place{
-	// 	PriceLevel:       POI.PriceLevelZero,
-	// 	Rating:           3.0,
-	// 	UserRatingsTotal: 0,
-	// }, POI.PlaceCategoryVisit)
-
 	tests := []struct {
 		place        []matching.Place
 		expectScore  float64
 		searchRadius int
 	}{
 		{[]matching.Place{testSinglePlaces[0]}, 0.2, 10000},
-		{[]matching.Place{testSinglePlaces[1]}, 0.0, 1000},
+		{[]matching.Place{testSinglePlaces[1]}, 1.8, 10000},
 	}
 
 	for _, test := range tests {
 		score := matching.Score(test.place, test.searchRadius)
-		assert.Equal(t, score, test.expectScore)
+		assert.Equal(t, test.expectScore, math.Ceil(score*100)/100)
 	}
 }


### PR DESCRIPTION
## Description
This change affects all the places with **Visit** category, since all their current price levels are zero. Previously the place rating to pricing ratios for Visit places are treated flatly, and this affect the result of score since the final score will only depend on the number of user ratings. With this change, the ratings for Visit places will be taken into account.

## Solution
* Modify the rating-to-pricing ratio to rating divided by the maximum score (5.0).

## Testing
- [x] Integration testing on Heroku staging
- [x] Added new unit tests

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
