### PR TITLE
Add Google photo URL validation

### DIFF
--- a/iowrappers/photos_client.go
+++ b/iowrappers/photos_client.go
@@ -10,6 +10,8 @@ import (
 	"golang.org/x/net/html"
 )
 
+const ValidPrefix = "https://lh3.googleusercontent.com/places/"
+
 type PhotoHttpClient struct {
 	// connect to Google Photo API
 	client     *http.Client
@@ -24,7 +26,7 @@ var isHtmlAnchor = func(node *html.Node) bool {
 }
 
 var isValidPhotoUrl = func(url string) bool {
-	return strings.HasPrefix(url, "https://lh3.googleusercontent.com/places/")
+	return strings.HasPrefix(url, ValidPrefix)
 }
 
 // CreatePhotoHttpClient is a factory method for PhotoClient
@@ -59,9 +61,9 @@ func (photoClient *PhotoHttpClient) GetPhotoURL(photoRef string) PhotoURL {
 	photoURL, err = parseHTML(body, isHtmlAnchor, isValidPhotoUrl)
 	if err != nil {
 		Logger.Warn("Err Msg: ", err.Error())
+		return ""
 	}
 	return photoURL
-
 }
 
 func parseHTML(htmlBody []byte, judger func(*html.Node) bool, validator func(string) bool) (PhotoURL, error) {

--- a/iowrappers/photos_client_test.go
+++ b/iowrappers/photos_client_test.go
@@ -38,21 +38,20 @@ func TestDfsParseHtmlForUrl(t *testing.T) {
 	<TITLE>Document</TITLE></HEAD><BODY>
 	<H1>Document</H1>
 	Test Data
-	<A HREF="https://www.link1.com/">here</A>.
-	<A HREF="https://www.link2.com/">here</A>.
+	<A HREF="www.google.com">here</A>.
+	<A HREF="https://lh3.googleusercontent.com/places/bbc">here</A>.
 	</BODY></HTML>`
 
 	tests := []struct {
 		HtmlBody string
-		Attr     string
 		Output   PhotoURL
 	}{
-		{htmlOneLink, "href", PhotoURL("https://lh3.googleusercontent.com/places/AAcXr")},
-		{htmlTwoLinks, "href", PhotoURL("https://www.link1.com/")},
+		{htmlOneLink, PhotoURL("https://lh3.googleusercontent.com/places/AAcXr")},
+		{htmlTwoLinks, PhotoURL("https://lh3.googleusercontent.com/places/bbc")},
 	}
 
 	for _, test := range tests {
-		url, err := parseHTML([]byte(test.HtmlBody), isHtmlAnchor, test.Attr)
+		url, err := parseHTML([]byte(test.HtmlBody), isHtmlAnchor, isValidPhotoUrl)
 		assert.Equal(t, url, test.Output)
 		assert.Empty(t, err, nil)
 	}
@@ -76,16 +75,15 @@ func TestDfsParseHtmlWithErr(t *testing.T) {
 
 	tests := []struct {
 		HtmlBody string
-		Attr     string
 		Output   PhotoURL
 		ErrMsg   string
 	}{
-		{htmlOneLink, "src", PhotoURL(""), "No URL is found in HTML body!"},
-		{htmlNoLink, "href", PhotoURL(""), "No URL is found in HTML body!"},
+		{htmlOneLink, PhotoURL(""), "No URL is found in HTML body!"},
+		{htmlNoLink, PhotoURL(""), "No URL is found in HTML body!"},
 	}
 
 	for _, test := range tests {
-		url, err := parseHTML([]byte(test.HtmlBody), isHtmlAnchor, test.Attr)
+		url, err := parseHTML([]byte(test.HtmlBody), isHtmlAnchor, isValidPhotoUrl)
 		assert.Equal(t, test.Output, url)
 		assert.Error(t, err, test.ErrMsg)
 	}


### PR DESCRIPTION
## Description
Some place may contain invalid photo URL, such as "www.google.com". see the example of "Birk's". 
![image](https://github.com/timwangmusic/Vacation-Planner/assets/54508739/185b10e0-e74f-4572-aed0-69be5ffc5d5a)


## Solution
Add a new URL validation function, and pass it into URL extraction function.
The new validator checks if the URL starts with a desired prefix. "https://lh3.googleusercontent.com/places/"

## Testing
- [] Integration testing on Heroku staging
- [x] Added new unit tests

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
