### PR TITLE
Set number of pages per planning results received

### DIFF
--- a/assets/js/plan_template.js
+++ b/assets/js/plan_template.js
@@ -213,16 +213,17 @@ function parseResponse(response) {
                     })
                 }
             )
-            // only shows the first 3 results
+
             $('#tables .table').slice(itemsPerPage).hide();
             $('#pagination').show();
             $('#pagination').pagination({
 
                 // Total number of items to be paginated
-                items: totalItemsCount,
+                items: plansCount,
 
                 // Items allowed on a single page
                 itemsOnPage: itemsPerPage,
+                pages: Math.ceil(plansCount / itemsPerPage),
                 onPageClick: function (pageIdx) {
                     const itemsOnPage = 2;
                     $('#tables .table').hide()


### PR DESCRIPTION
## Description
We used to have a fixed number of pages (5 pages for 10 results) for plan template result section. This is not ideal when the number of results is less than or more than 10 since some pages will show blanks.

## Solution
* Set pages per planning results received.

## Testing
- [ ] Integration testing on Heroku staging
- [ ] Added new unit tests

## Checks
- [ ] Have you removed commented code?
- [ ] Have you used gofmt to format your code?
