### PR TITLE
Enhancement: collect planning solutions when timeout happens

### DIFF
--- a/assets/js/plan_template.js
+++ b/assets/js/plan_template.js
@@ -140,7 +140,7 @@ async function postPlanTemplate() {
     console.log(`data about to send: ${JSON.stringify(data)}`);
 
     axios.post(
-        url, JSON.stringify(data), { timeout: 10000 }
+        url, JSON.stringify(data), { timeout: 15000 }
     ).then(
         function (response) {
             console.log(response.data);

--- a/test/solution_candidate_selection_test.go
+++ b/test/solution_candidate_selection_test.go
@@ -31,18 +31,17 @@ func TestSolutionCandidateSelection(t *testing.T) {
 	}
 	topSolutionsCount := 5
 	res := s.FindBestPlanningSolutions(context.Background(), clusters, topSolutionsCount, iterator)
-	resp := <-res
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if len(resp.Solutions) != topSolutionsCount {
-		t.Fatalf("expected number of solutions equals %d, got %d", topSolutionsCount, len(res))
+	if len(res.Solutions) != topSolutionsCount {
+		t.Fatalf("expected number of solutions equals %d, got %d", topSolutionsCount, len(res.Solutions))
 	}
 
 	// Suggested top five plan scores should match top five ratings
 	expectation := []float64{99, 98, 97, 96, 95}
-	for idx, r := range resp.Solutions {
+	for idx, r := range res.Solutions {
 		if r.Score != expectation[idx] {
 			t.Errorf("expected %f, got %f", expectation[idx], r.Score)
 		}


### PR DESCRIPTION
## Description
When users query for a large number of time slots (>4) a regular server typically fail to examine all the possible solutions. We could consider collect solutions when computational timeout happen.

## Solution
* Collect planning solutions when computational timeout happens.
* Move timeout context to `FindBestPlanningSolutions` method since its caller do not need to be aware of this mechanism.
* Remove computational timeout error.
* Increase front-end timeout from 10s to 15s.

## Testing
- [x] Integration testing on Heroku staging
- [x] Added new unit tests

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
