### PR TITLE
[Enhancement] Sort places by score before solving combinatorics

### DIFF
--- a/matching/score.go
+++ b/matching/score.go
@@ -17,7 +17,7 @@ const (
 // TODO, RW: remove in the future
 func ScoreOld(places []Place) float64 {
 	if len(places) == 1 {
-		return singlePlaceScore(places[0])
+		return PlaceScore(places[0])
 	}
 	distances := calDistances(places)                     // Haversine distances
 	maxDist := math.Max(0.001, calMaxDistance(distances)) // protect against maximum distance being zero
@@ -30,7 +30,7 @@ func ScoreOld(places []Place) float64 {
 // Score uses constant distance normalisation factor
 func Score(places []Place, distNorm int) float64 {
 	if len(places) == 1 {
-		return singlePlaceScore(places[0])
+		return PlaceScore(places[0])
 	}
 	distances := calDistances(places)                            // Haversine distances
 	avgDistance := stat.Mean(distances, nil) / float64(distNorm) // normalized average distance
@@ -39,7 +39,7 @@ func Score(places []Place, distNorm int) float64 {
 	return avgScore - avgDistance
 }
 
-func singlePlaceScore(place Place) float64 {
+func PlaceScore(place Place) float64 {
 	var boostFactor float64
 	if place.PlacePrice() == 0 {
 		boostFactor = float64(place.Rating()) / MaxPlaceRating
@@ -70,7 +70,7 @@ func avgPlacesScore(places []Place) float64 {
 	numPlaces := len(places)
 	placeScores := make([]float64, numPlaces)
 	for k, place := range places {
-		placeScores[k] = singlePlaceScore(place)
+		placeScores[k] = PlaceScore(place)
 	}
 	return stat.Mean(placeScores, nil)
 }

--- a/matching/score_test.go
+++ b/matching/score_test.go
@@ -1,0 +1,43 @@
+package matching
+
+import (
+	"github.com/weihesdlegend/Vacation-planner/POI"
+	"testing"
+)
+
+func TestPlaceScore(t *testing.T) {
+	type args struct {
+		place Place
+	}
+	tests := []struct {
+		name string
+		args args
+		want float64
+	}{
+		{
+			name: "test compute place score with zero price should return correct result",
+			args: args{place: Place{
+				Place:    &POI.Place{Name: "Local Park", UserRatingsTotal: 99, Rating: 4.0},
+				Category: POI.PlaceCategoryVisit,
+				Price:    0,
+			}},
+			want: 1.6,
+		},
+		{
+			name: "test compute place score with price at level two should return correct result",
+			args: args{place: Place{
+				Place:    &POI.Place{Name: "Uncle Pizza", UserRatingsTotal: 999, Rating: 4.0},
+				Category: POI.PlaceCategoryEatery,
+				Price:    2,
+			}},
+			want: 6.0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := PlaceScore(tt.args.place); got != tt.want {
+				t.Errorf("PlaceScore() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/planner/solver.go
+++ b/planner/solver.go
@@ -1,6 +1,7 @@
 package planner
 
 import (
+	"cmp"
 	"container/heap"
 	"context"
 	"errors"
@@ -537,6 +538,8 @@ func (s *Solver) generatePlacesForSlots(ctx context.Context, req *PlanningReques
 		if len(placesByPrice) == 0 {
 			return nil, fmt.Errorf("failed to find any place for category %s at slot %s for location %+v", slot.Category, slot.TimeSlot.ToString(), req.Location)
 		}
+		// sort places by score descending so the solver checks places with higher score first
+		slices.SortFunc(placesByPrice, func(a, b matching.Place) int { return cmp.Compare(matching.PlaceScore(b), matching.PlaceScore(a)) })
 		placeClusters = append(placeClusters, placesByPrice)
 	}
 	return placeClusters, nil


### PR DESCRIPTION
## Description
Now we are doing early termination when solving combinatorics. So the idea is if the input place lists are sorted by score, the solver would be able to check the places with higher score first, resulting in higher quality plans in general.

## Solution
* export the function to compute single place score to the higher level packages
* sort places by score before solving the combination problem.

## Testing
- [x] Integration testing on Heroku staging
- [x] Added new unit tests

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
