### PR TITLE
Make all default return of photo URLs to be empty string

### DIFF
--- a/iowrappers/photos_client.go
+++ b/iowrappers/photos_client.go
@@ -46,16 +46,17 @@ func (photoClient *PhotoHttpClient) GetPhotoURL(photoRef string) PhotoURL {
 	res, err := photoClient.client.Get(reqURL)
 	if err != nil {
 		Logger.Fatal(err)
-		return photoURL
+		return ""
 	}
 	body, err := io.ReadAll(res.Body)
 	res.Body.Close()
 	if res.StatusCode != 302 {
 		Logger.Warnf("status code should be 302, but is %d", res.StatusCode)
+		return ""
 	}
 	if err != nil {
 		Logger.Fatal(err)
-		return photoURL
+		return ""
 	}
 
 	photoURL, err = parseHTML(body, isHtmlAnchor, isValidPhotoUrl)


### PR DESCRIPTION
## Description
Make all default return of photo URLs to be empty string

## Solution
* Align all return values to be an empty string when failed processing happens 

## Testing
- [ ] Integration testing on Heroku staging
- [ ] Added new unit tests

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
