### PR TITLE
Setup alternative call for planner to use Google maps PhotoClient

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -10,3 +10,4 @@ server:
   plan_solver:
     same_place_dedupe_count_limit: 2
     nearby_cities_count_limit: 3
+    enable_maps_photo_client: false

--- a/iowrappers/photos_client_test.go
+++ b/iowrappers/photos_client_test.go
@@ -10,22 +10,6 @@ func init() {
 	_ = CreateLogger()
 }
 
-func TestCreatePhotoClient(t *testing.T) {
-	tests := []struct {
-		apiKey  string
-		baseURL string
-	}{
-		{"abcd", "https://foos.com"},
-		{"xyz", "https://www.google.com"},
-	}
-
-	for _, test := range tests {
-		client := CreatePhotoHttpClient(test.apiKey, test.baseURL)
-		assert.Equal(t, client.apiKey, test.apiKey)
-		assert.Equal(t, client.apiBaseURL, test.baseURL)
-	}
-}
-
 func TestDfsParseHtmlForUrl(t *testing.T) {
 	var htmlOneLink = `<HTML><HEAD><meta http-equiv="content-type" content="text/html;charset=utf-8">
 	<TITLE>302 Moved</TITLE></HEAD><BODY>

--- a/main.go
+++ b/main.go
@@ -38,8 +38,9 @@ type Configurations struct {
 		} `yaml:"google_maps"`
 
 		PlanSolver struct {
-			SamePlaceDedupeCountLimit int `yaml:"same_place_dedupe_count_limit"`
-			NearbyCitiesCountLimit    int `yaml:"nearby_cities_count_limit"`
+			SamePlaceDedupeCountLimit int  `yaml:"same_place_dedupe_count_limit"`
+			NearbyCitiesCountLimit    int  `yaml:"nearby_cities_count_limit"`
+			EnableMapsPhotoClient     bool `yaml:"enable_maps_photo_client"`
 		} `yaml:"plan_solver"`
 	} `yaml:"server"`
 }
@@ -50,6 +51,7 @@ func flattenConfig(configs *Configurations) map[string]interface{} {
 	flattenedConfigs["server:google_maps:detailed_search_fields"] = configs.Server.GoogleMaps.DetailedSearchFields
 	flattenedConfigs["server:plan_solver:same_place_dedupe_count_limit"] = configs.Server.PlanSolver.SamePlaceDedupeCountLimit
 	flattenedConfigs["server:plan_solver:nearby_cities_count_limit"] = configs.Server.PlanSolver.NearbyCitiesCountLimit
+	flattenedConfigs["server:plan_solver:enable_maps_photo_client"] = configs.Server.PlanSolver.EnableMapsPhotoClient
 	return flattenedConfigs
 }
 


### PR DESCRIPTION
## Description
To fix the missing photo issue, we want to experiment using Google maps photo api. Currently the planner uses a native http client that does send some customized request.

## Solution
* Define a new interface PhotoClient, insert it as a data member in Planner
* Add a flag "enable_maps_photo_client"
* Removed redundant unit tests

## Testing
- [x] Integration testing in local build
- [x] Removed new unit tests

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
