### PR TITLE
Chore: move Zap logger init to main

### DIFF
--- a/iowrappers/maps_client.go
+++ b/iowrappers/maps_client.go
@@ -34,7 +34,6 @@ func (c *MapsClient) SetDetailedSearchFields(fields []string) {
 
 // CreateMapsClient is a factory method for MapsClient
 func CreateMapsClient(apiKey string) *MapsClient {
-	logErr(CreateLogger(), utils.LogError)
 	mapsClient, err := maps.NewClient(maps.WithAPIKey(apiKey))
 	if err != nil {
 		Logger.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"github.com/weihesdlegend/Vacation-planner/iowrappers"
+	"github.com/weihesdlegend/Vacation-planner/utils"
 	"net/url"
 	"os"
 	"os/signal"
@@ -43,6 +45,10 @@ type Configurations struct {
 			EnableMapsPhotoClient     bool `yaml:"enable_maps_photo_client"`
 		} `yaml:"plan_solver"`
 	} `yaml:"server"`
+}
+
+func init() {
+	utils.LogErrorWithLevel(iowrappers.CreateLogger(), utils.LogFatal)
 }
 
 // flatten configs as a key-value map

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -124,6 +124,7 @@ type PlaceDetailsResp struct {
 type RequestIdKey string
 
 func (p *MyPlanner) Init(mapsClientApiKey string, redisURL *url.URL, redisStreamName string, configs map[string]interface{}, oauthClientID string, oauthClientSecret string, domain string, geonamesApiKey string) {
+	logger := iowrappers.Logger
 	p.PlanningEvents = make(chan iowrappers.PlanningEvent, jobQueueBufferSize)
 	p.RedisClient = iowrappers.CreateRedisClient(redisURL)
 	p.RedisStreamName = redisStreamName
@@ -146,14 +147,14 @@ func (p *MyPlanner) Init(mapsClientApiKey string, redisURL *url.URL, redisStream
 	p.Configs = configs
 
 	// initialize photo client
-	var enable_maps_photo_client = false
-	if flag_enable_maps_photo_client, exists := p.Configs["server:plan_solver:enable_maps_photo_client"]; exists {
-		enable_maps_photo_client = flag_enable_maps_photo_client.(bool)
-		log.Debugf("flag server:plan_solver:enable_maps_photo_client: %v\n", enable_maps_photo_client)
+	var enableMapsPhotoClient = false
+	if flagEnableMapsPhotoClient, exists := p.Configs["server:plan_solver:enable_maps_photo_client"]; exists {
+		enableMapsPhotoClient = flagEnableMapsPhotoClient.(bool)
+		logger.Debugf("flag server:plan_solver:enableMapsPhotoClient: %v\n", enableMapsPhotoClient)
 	} else {
-		log.Errorf("failed to load flag server:plan_solver:enable_maps_photo_client!")
+		logger.Errorf("failed to load flag server:plan_solver:enableMapsPhotoClient!")
 	}
-	p.PhotoClient = iowrappers.CreatePhotoClient(mapsClientApiKey, PhotoApiBaseURL, enable_maps_photo_client)
+	p.PhotoClient = iowrappers.CreatePhotoClient(mapsClientApiKey, PhotoApiBaseURL, enableMapsPhotoClient)
 
 	// initialize poi searcher
 	PoiSearcher := iowrappers.CreatePoiSearcher(mapsClientApiKey, redisURL)
@@ -162,7 +163,7 @@ func (p *MyPlanner) Init(mapsClientApiKey string, redisURL *url.URL, redisStream
 			p.Solver.Init(PoiSearcher, v.(int), c.(int))
 		}
 	} else {
-		log.Fatal("failed to initialize the plan solver.")
+		logger.Fatal("failed to initialize the planner")
 	}
 
 	if v, exists := p.Configs["server:google_maps:detailed_search_fields"]; exists {
@@ -172,7 +173,7 @@ func (p *MyPlanner) Init(mapsClientApiKey string, redisURL *url.URL, redisStream
 	var err error
 	geocodes, err = p.RedisClient.GetCities(context.Background())
 	if err != nil {
-		log.Errorf("failed to load city geocodes: %v", err.Error())
+		logger.Errorf("failed to load city geocodes: %v", err.Error())
 	}
 	p.OAuth2Config = &oauth2.Config{
 		ClientID:     oauthClientID,
@@ -184,9 +185,10 @@ func (p *MyPlanner) Init(mapsClientApiKey string, redisURL *url.URL, redisStream
 	if p.Environment == ProductionEnvironment || p.Environment == TestingEnvironment {
 		p.Mailer = &iowrappers.Mailer{}
 		if err = p.Mailer.Init(p.RedisClient); err != nil {
-			log.Fatalf("p failed to create a Mailer: %s", err.Error())
+			logger.Fatalf("p failed to create a Mailer: %s", err.Error())
 		}
 	}
+	logger.Info("The planner initialization process completes")
 }
 
 func (p *MyPlanner) Destroy() {

--- a/planner/solver.go
+++ b/planner/solver.go
@@ -98,13 +98,6 @@ type SlotRequest struct {
 	Category POI.PlaceCategory `json:"category"`
 }
 
-func init() {
-	err := iowrappers.CreateLogger()
-	if err != nil {
-		log.Error(err)
-	}
-}
-
 func (s *Solver) Init(poiSearcher *iowrappers.PoiSearcher, placeDedupeCountLimit int, nearbyCitiesCountLimit int) {
 	s.Searcher = poiSearcher
 	s.placeDedupeCountLimit = placeDedupeCountLimit

--- a/planner/solver_test.go
+++ b/planner/solver_test.go
@@ -7,9 +7,14 @@ import (
 	"github.com/weihesdlegend/Vacation-planner/POI"
 	"github.com/weihesdlegend/Vacation-planner/iowrappers"
 	"github.com/weihesdlegend/Vacation-planner/matching"
+	"github.com/weihesdlegend/Vacation-planner/utils"
 	"reflect"
 	"testing"
 )
+
+func init() {
+	utils.LogErrorWithLevel(iowrappers.CreateLogger(), utils.LogFatal)
+}
 
 func TestSolver_filterPlaces1(t *testing.T) {
 	type fields struct {


### PR DESCRIPTION
## Description
Remove double init in `solver.go`

## Solution
* Move the logger initialization to the program entry
* Also rename a few variables for consistency
* Keep the `Logger` in `iowrappers` package since it is for IO purposes.

## Testing
- [ ] Integration testing on Heroku staging
- [ ] Added new unit tests

## Checks
- [ ] Have you removed commented code?
- [ ] Have you used gofmt to format your code?
