### PR TITLE
Feat: add load more plans button in user profile page

### DIFF
--- a/assets/js/user_profile.js
+++ b/assets/js/user_profile.js
@@ -92,7 +92,9 @@ function getUserPlans() {
         for (let i = 0; i < plans.length; i++) {
           renderCard(plans[i], i);
         }
-        $("#load-more-plans-btn").css("display", "");
+        if (plans.length > initNumPlansShown) {
+          $("#load-more-plans-btn").css("display", "");
+        }
       }
     })
     .catch((err) => console.error(err));

--- a/assets/js/user_profile.js
+++ b/assets/js/user_profile.js
@@ -1,6 +1,8 @@
 import { updateUsername } from "./user.js";
 
 const username = updateUsername();
+const initNumPlansShown = 3;
+let numPlansShown = initNumPlansShown;
 
 async function deleteUserPlan() {
   const username = this.dataset.user;
@@ -16,9 +18,12 @@ async function deleteUserPlan() {
     .catch((err) => console.error(err));
 }
 
-function renderCard(plan) {
+function renderCard(plan, idx) {
   const cards = $("#cards");
   let card = $("<div>").addClass("card rounded mb-2").css("max-width", "350px");
+  if (idx >= numPlansShown) {
+    card.css("display", "none");
+  }
   let cardBody = $("<div>").addClass("card-body");
   cardBody.append($("<h5>").addClass("card-title").text(plan.destination));
   cardBody.append($("<h6>").addClass("card-subtitle").text(plan.travel_date));
@@ -85,8 +90,9 @@ function getUserPlans() {
       const plans = data["travel_plans"];
       if (plans.length > 0) {
         for (let i = 0; i < plans.length; i++) {
-          renderCard(plans[i]);
+          renderCard(plans[i], i);
         }
+        $("#load-more-plans-btn").css("display", "");
       }
     })
     .catch((err) => console.error(err));
@@ -109,5 +115,22 @@ function getUserFavorites() {
 async function renderUserProfile() {
   await Promise.all([getUserPlans(), getUserFavorites()]);
 }
+
+$("#load-more-plans-btn").on("click", () => {
+  numPlansShown = numPlansShown + 3;
+  $("#cards")
+    .children()
+    .each((idx, card) => {
+      if (idx >= numPlansShown) {
+        card.style.display = "none";
+      } else {
+        card.style.display = "";
+      }
+    });
+  // hide the load more button when all plans are shown
+  if (numPlansShown >= $("#cards").children().length) {
+    $("#load-more-plans-btn").css("display", "none");
+  }
+});
 
 renderUserProfile().then(() => console.log("user profile is loaded"));

--- a/assets/templates/user_profile.html
+++ b/assets/templates/user_profile.html
@@ -34,6 +34,7 @@
             <div class="col">
                 <h4>Saved Travel Plans</h4>
                 <div id="cards"></div>
+                <button type="button" class="btn btn-outline-primary" id="load-more-plans-btn" style="display: none;">Load more</button>
             </div>
             <div class="col">
                 <h4>Personal Favorites</h4>


### PR DESCRIPTION
## Description
The number of plans users save may get very large. It looks nice if users can load more plans progressively.

## Solution
* Set initial number of displayed plans to 3.
* Show load more button when the number of plans is greater than 3.
* Each time user clicks on the load more button, at most 3 more plans are shown.

## Testing
- [x] Integration testing on Heroku staging
- [ ] Added new unit tests

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
