### PR TITLE
Experiment: Update default search radius to 20km

### DIFF
--- a/planner/planner.go
+++ b/planner/planner.go
@@ -524,7 +524,7 @@ func (p *MyPlanner) getPlanningApi(ctx *gin.Context) {
 
 	planningReq := standardRequest(date, toWeekday(date), numResultsInt, toPriceLevel(priceLevel))
 	planningReq.WithNearbyCities = enableNearbyCities
-	planningReq.SearchRadius = 10000 // default to 10km
+	planningReq.SearchRadius = DefaultPlaceSearchRadius
 	planningReq.PreciseLocation = preciseLocation
 	logger.Debugf("use precise location: %t", preciseLocation)
 	if preciseLocation {

--- a/planner/solver.go
+++ b/planner/solver.go
@@ -23,7 +23,7 @@ import (
 const (
 	NumPlansDefault                       = 5
 	TopSolutionsCountDefault              = 5
-	DefaultPlaceSearchRadius              = 10000
+	DefaultPlaceSearchRadius              = 20000 // default to 20km (~12.43 miles)
 	CategorizedPlaceIterInitFailureErrMsg = "categorized places iterator init failure"
 	ErrMsgMismatchIterAndPlace            = "mismatch in iterator status vector length"
 	ErrMsgRepeatedPlaceInSameTrip         = "repeated places in the same trip"
@@ -293,7 +293,7 @@ func standardRequest(travelDate string, weekday POI.Weekday, numResults int, pri
 	return
 }
 
-func createPlanningSolutionCandidate(placeIndexes []int, placeClusters [][]matching.Place) (PlanningSolution, error) {
+func createPlanningSolutionCandidate(placeIndexes []int, placeClusters [][]matching.Place, radius uint) (PlanningSolution, error) {
 	var res PlanningSolution
 	if len(placeIndexes) != len(placeClusters) {
 		return res, errors.New(ErrMsgMismatchIterAndPlace)
@@ -327,14 +327,14 @@ func createPlanningSolutionCandidate(placeIndexes []int, placeClusters [][]match
 		}
 		res.PlaceURLs = append(res.PlaceURLs, place.Url())
 	}
-	// TODO: replace default search radius with user search input
-	res.Score = matching.Score(places, DefaultPlaceSearchRadius)
+
+	res.Score = matching.Score(places, int(radius))
 	res.ScoreOld = matching.ScoreOld(places)
 	res.ID = uuid.NewString()
 	return res, nil
 }
 
-func (s *Solver) FindBestPlanningSolutions(ctx context.Context, placeClusters [][]matching.Place, topSolutionsCount int, iterator *MultiDimIterator) (resp *PlanningResp) {
+func (s *Solver) FindBestPlanningSolutions(ctx context.Context, placeClusters [][]matching.Place, topSolutionsCount int, iterator *MultiDimIterator, radius uint) (resp *PlanningResp) {
 	if topSolutionsCount <= 0 {
 		topSolutionsCount = TopSolutionsCountDefault
 	}
@@ -354,7 +354,7 @@ func (s *Solver) FindBestPlanningSolutions(ctx context.Context, placeClusters []
 		default:
 			var candidate PlanningSolution
 			var err error
-			candidate, err = createPlanningSolutionCandidate(iterator.Status, placeClusters)
+			candidate, err = createPlanningSolutionCandidate(iterator.Status, placeClusters, radius)
 			iterator.Next()
 			if err != nil {
 				log.Debug(err)
@@ -513,7 +513,7 @@ func (s *Solver) generatePlacesForSlots(ctx context.Context, req *PlanningReques
 		}
 
 		places, err := matching.NearbySearchForCategory(ctx, s.Searcher, &matching.Request{
-			Radius:             DefaultPlaceSearchRadius,
+			Radius:             req.SearchRadius,
 			Location:           req.Location,
 			Category:           slot.Category,
 			UsePreciseLocation: req.PreciseLocation,
@@ -575,7 +575,7 @@ func (s *Solver) generateSolutions(ctx context.Context, req *PlanningRequest) (r
 		return
 	}
 
-	return s.FindBestPlanningSolutions(ctx, placeClusters, req.NumPlans, mdIter)
+	return s.FindBestPlanningSolutions(ctx, placeClusters, req.NumPlans, mdIter, req.SearchRadius)
 }
 
 func saveSolutions(ctx context.Context, c *iowrappers.RedisClient, req *PlanningRequest, solutions []PlanningSolution) error {

--- a/test/solution_candidate_selection_test.go
+++ b/test/solution_candidate_selection_test.go
@@ -30,7 +30,7 @@ func TestSolutionCandidateSelection(t *testing.T) {
 		t.Fatal(err)
 	}
 	topSolutionsCount := 5
-	res := s.FindBestPlanningSolutions(context.Background(), clusters, topSolutionsCount, iterator)
+	res := s.FindBestPlanningSolutions(context.Background(), clusters, topSolutionsCount, iterator, planner.DefaultPlaceSearchRadius)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Description
Previously the default search radius is 10km, which is quite limited for larger cities. The average radius of the 10 most populated cities in the US is around 18.84 miles.

## Solution
* Increase default search radius to 20km (~ 12.34 miles) so we consider more places for planning requests.
* Address a TODO item where the computation for best planning results should consider search radius from input instead of using the default.

## Testing
- [x] Integration testing on Heroku staging
- [ ] Added new unit tests

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
