### PR TITLE
Increase default number of time slots for plans to 4

### DIFF
--- a/planner/solver.go
+++ b/planner/solver.go
@@ -278,7 +278,7 @@ func standardRequest(travelDate string, weekday POI.Weekday, numResults int, pri
 		Weekday:  weekday,
 	}
 
-	timeSlot3 := matching.TimeSlot{Slot: POI.TimeInterval{Start: 13, End: 17}}
+	timeSlot3 := matching.TimeSlot{Slot: POI.TimeInterval{Start: 14, End: 17}}
 
 	slotReq3 := SlotRequest{
 		TimeSlot: timeSlot3,
@@ -286,7 +286,14 @@ func standardRequest(travelDate string, weekday POI.Weekday, numResults int, pri
 		Weekday:  weekday,
 	}
 
-	req.Slots = append(req.Slots, []SlotRequest{slotReq1, slotReq2, slotReq3}...)
+	timeSlot4 := matching.TimeSlot{Slot: POI.TimeInterval{Start: 18, End: 20}}
+	slotReq4 := SlotRequest{
+		TimeSlot: timeSlot4,
+		Category: POI.PlaceCategoryEatery,
+		Weekday:  weekday,
+	}
+
+	req.Slots = append(req.Slots, []SlotRequest{slotReq1, slotReq2, slotReq3, slotReq4}...)
 	req.TravelDate = travelDate
 	req.NumPlans = numResults
 	req.PriceLevel = priceLevel


### PR DESCRIPTION
## Description
Increase default number of time slots for plans from 3 to 4 since we can handle the extra computational complexity now.

## Solution
* Add "dinner" time slot from 6PM to 8PM.
* Modify afternoon visit time slot from 1PM to 2PM.

## Testing
- [x] Integration testing on Heroku staging

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
