### PR TITLE
Improve saving and retrieving planning solutions

### DIFF
--- a/iowrappers/users.go
+++ b/iowrappers/users.go
@@ -312,7 +312,7 @@ func (r *RedisClient) SaveUserPlan(context context.Context, userView user.View, 
 	travelPlanRedisKey := strings.Join([]string{TravelPlanRedisCacheKeyPrefix, planView.OriginalPlanID}, ":")
 	userSavedPlansRedisKey := strings.Join([]string{UserSavedTravelPlansPrefix, "user", userView.ID, "plans"}, ":")
 	if exists, getPlanErr := r.client.SIsMember(context, userSavedPlansRedisKey, travelPlanRedisKey).Result(); getPlanErr != nil || exists {
-		if getPlanErr != nil && getPlanErr != redis.Nil {
+		if getPlanErr != nil && !errors.Is(getPlanErr, redis.Nil) {
 			return getPlanErr
 		}
 		if exists {

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -673,7 +673,7 @@ func (p *MyPlanner) customize(ctx *gin.Context) {
 		ctx.String(http.StatusBadRequest, err.Error())
 		return
 	}
-	iowrappers.Logger.Debugf("received date in request: %s", date)
+	logger.Debugf("received date in request: %s", date)
 
 	priceLevel := ctx.DefaultQuery("price", "2")
 	logger.Debugf("Requested price range is %s", priceLevel)
@@ -691,7 +691,7 @@ func (p *MyPlanner) customize(ctx *gin.Context) {
 	}
 
 	if err := ctx.ShouldBindJSON(&request); err != nil {
-		iowrappers.Logger.Error(err)
+		logger.Error(err)
 		ctx.Status(http.StatusBadRequest)
 		return
 	}
@@ -703,7 +703,7 @@ func (p *MyPlanner) customize(ctx *gin.Context) {
 
 	c := context.WithValue(ctx, iowrappers.ContextRequestIdKey, requestid.Get(ctx))
 	planningResp := p.Planning(c, request, "guest")
-	iowrappers.Logger.Debugf("response status code is: %d", planningResp.StatusCode)
+	logger.Debugf("response status code is: %d", planningResp.StatusCode)
 	if planningResp.StatusCode == RequestTimeOut {
 		ctx.JSON(http.StatusRequestTimeout, nil)
 	}

--- a/test/redis_client_mocks/cached_planning_solutions_test.go
+++ b/test/redis_client_mocks/cached_planning_solutions_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 )
 
-func TestGetCachedPlanningSolutions_shouldReturnCorrectRecords(t *testing.T) {
-	cacheRequest1 := &iowrappers.PlanningSolutionsSaveRequest{
+func TestGetSavedPlanningSolutions_shouldReturnCorrectResults(t *testing.T) {
+	request1 := &iowrappers.PlanningSolutionsSaveRequest{
 		Location: POI.Location{City: "Beijing", Country: "China"},
 		Intervals: []POI.TimeInterval{
 			{
@@ -28,49 +28,63 @@ func TestGetCachedPlanningSolutions_shouldReturnCorrectRecords(t *testing.T) {
 			POI.PlaceCategoryVisit,
 			POI.PlaceCategoryEatery,
 		},
-		PlanningSolutionRecords: make([]iowrappers.PlanningSolutionRecord, 1),
+		PlanningSolutionRecords: []iowrappers.PlanningSolutionRecord{
+			{
+				ID:         "33521-12533",
+				PlaceIDs:   []string{"1", "2"},
+				Score:      100,
+				PlaceNames: []string{"Tian Tan Park", "Yuan Ming Yuan"},
+			},
+		},
 	}
-	cacheRequest1.PlanningSolutionRecords[0].PlaceIDs = []string{"1", "2"}
-	cacheRequest1.PlanningSolutionRecords[0].ID = "33521-12533"
 
 	var err error
-	err = RedisClient.SavePlanningSolutions(RedisContext, cacheRequest1)
+	err = RedisClient.SavePlanningSolutions(RedisContext, request1)
 	if err != nil {
 		t.Error(err)
 		return
 	}
 
-	cacheRequest2 := &iowrappers.PlanningSolutionsSaveRequest{
-		Location:                POI.Location{City: "San Francisco", Country: "United States"},
-		PlanningSolutionRecords: make([]iowrappers.PlanningSolutionRecord, 1),
+	request2 := &iowrappers.PlanningSolutionsSaveRequest{
+		Location: POI.Location{City: "San Francisco", Country: "United States"},
+		PlanningSolutionRecords: []iowrappers.PlanningSolutionRecord{
+			{
+				ID:       "33522-22533",
+				PlaceIDs: []string{"111", "222", "333"},
+			},
+		},
 	}
-	cacheRequest2.PlanningSolutionRecords[0].ID = "33522-22533"
-	cacheRequest2.PlanningSolutionRecords[0].PlaceIDs = []string{"111", "222", "333"}
 
-	err = RedisClient.SavePlanningSolutions(RedisContext, cacheRequest2)
+	err = RedisClient.SavePlanningSolutions(RedisContext, request2)
 	if err != nil {
 		t.Error(err)
 		return
 	}
 
-	cacheResponse, err := RedisClient.PlanningSolutions(RedisContext, cacheRequest1)
+	planningSolutions, err := RedisClient.PlanningSolutions(RedisContext, request1)
 
 	if err != nil {
 		t.Error(err)
 		return
 	}
 
-	for idx, planningSolution := range cacheResponse.PlanningSolutionRecords {
-		assert.Equal(t, cacheRequest1.PlanningSolutionRecords[idx].PlaceIDs, planningSolution.PlaceIDs)
+	for idx, planningSolution := range planningSolutions.PlanningSolutionRecords {
+		record := request1.PlanningSolutionRecords[idx]
+		assert.Equal(t, record.ID, planningSolution.ID)
+		assert.Equal(t, record.PlaceIDs, planningSolution.PlaceIDs)
+		assert.Equal(t, record.Score, planningSolution.Score)
+		assert.Equal(t, record.PlaceNames, planningSolution.PlaceNames)
 	}
 
-	cacheResponse, err = RedisClient.PlanningSolutions(RedisContext, cacheRequest2)
+	planningSolutions, err = RedisClient.PlanningSolutions(RedisContext, request2)
 	if err != nil {
 		t.Error(err)
 		return
 	}
 
-	for idx, planningSolution := range cacheResponse.PlanningSolutionRecords {
-		assert.Equal(t, cacheRequest2.PlanningSolutionRecords[idx].PlaceIDs, planningSolution.PlaceIDs)
+	for idx, planningSolution := range planningSolutions.PlanningSolutionRecords {
+		record := request2.PlanningSolutionRecords[idx]
+		assert.Equal(t, record.ID, planningSolution.ID)
+		assert.Equal(t, record.PlaceIDs, planningSolution.PlaceIDs)
 	}
 }


### PR DESCRIPTION
## Description
Made saving and retrieving planning solutions more robust and less error prone.

## Solution
* When saving planning solutions, we should first make sure the plan is saved before saving its ID. We are now also cleaning up previous plan IDs if they exist.
* When retrieving planning solutions, we should make sure the plan details are fetched before adding them to the results. Previously we could end up with incomplete results.

## Testing
- [x] Integration testing on Heroku staging
- [x] Added new unit tests

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
