### PR TITLE
Fix: avoid re-generating plans when results are less than requested

### DIFF
--- a/iowrappers/redis_client.go
+++ b/iowrappers/redis_client.go
@@ -646,9 +646,9 @@ func (r *RedisClient) SavePlanningSolutions(ctx context.Context, request *Planni
 	return nil
 }
 
-func (r *RedisClient) PlanningSolutions(ctx context.Context, request *PlanningSolutionsSaveRequest) (PlanningSolutionsResponse, error) {
+func (r *RedisClient) PlanningSolutions(ctx context.Context, request *PlanningSolutionsSaveRequest) (*PlanningSolutionsResponse, error) {
 	Logger.Debugf("->RedisClient.PlanningSolutions(%v)", request)
-	var response PlanningSolutionsResponse
+	var response = &PlanningSolutionsResponse{}
 	redisListKey, keyGenerationErr := generateTravelPlansCacheKey(request)
 	if keyGenerationErr != nil {
 		Logger.Error(keyGenerationErr)

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -38,6 +38,7 @@ const (
 	SolverTimeout      = time.Second * 10
 	jobQueueBufferSize = 1000
 	PhotoApiBaseURL    = "https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&photo_reference=%s&key=%s"
+	requestIdKey       = "request_id"
 )
 
 type Environment string
@@ -468,6 +469,8 @@ func (p *MyPlanner) getOptimalPlan(ctx *gin.Context) {
 // Return top planning results to user
 func (p *MyPlanner) getPlanningApi(ctx *gin.Context) {
 	logger := iowrappers.Logger
+	requestId := requestid.Get(ctx)
+	ctx.Set(requestIdKey, requestId)
 
 	var userView user.View
 	var authenticationErr error
@@ -479,7 +482,6 @@ func (p *MyPlanner) getPlanningApi(ctx *gin.Context) {
 	}
 
 	logger.Debugf("->getPlanningApi: user view: %+v", userView)
-	requestId := requestid.Get(ctx)
 
 	var err error
 	var preciseLocation bool

--- a/planner/solver.go
+++ b/planner/solver.go
@@ -230,7 +230,7 @@ func (s *Solver) Solve(ctx context.Context, req *PlanningRequest) *PlanningResp 
 	cacheResponse, cacheErr := redisClient.PlanningSolutions(ctx, cacheRequest)
 
 	var resp = &PlanningResp{}
-	if cacheErr != nil || len(cacheResponse.PlanningSolutionRecords) < req.NumPlans {
+	if cacheErr != nil || len(cacheResponse.PlanningSolutionRecords) == 0 {
 		resp = s.generateSolutions(ctx, req)
 		if resp.Err == nil {
 			if err := saveSolutions(ctx, redisClient, req, resp.Solutions); err != nil {

--- a/planner/users.go
+++ b/planner/users.go
@@ -161,7 +161,7 @@ func (p *MyPlanner) UserAuthentication(ctx *gin.Context, minimumUserLevel user.L
 		return userView, errors.New("failed to parse JWT claims")
 	}
 
-	iowrappers.Logger.Debugf("the current logged-in user is %s", username)
+	iowrappers.Logger.Debugf("[request ID: %s] The current logged-in user is %s", ctx.Value(requestIdKey), username)
 
 	userView, findUserErr := p.RedisClient.FindUser(ctx, iowrappers.FindUserByName, user.View{Username: username})
 	if findUserErr != nil {


### PR DESCRIPTION
## Description
When users select higher price levels, the number of candidate places become less. In these cases, the number of available plans are sometimes less than requested. As the same set of candidate places that are used in generating the plans, we are repeatedly generating the same plans over and over again. This is not scalable and wasting computation/storage resources.

## Solution
* Remove the constraint that the number of saved plans has to be larger than requested.
* `RedisClient.PlanningSolutions` method now returns a pointer instead of a struct.
* Add request ID when users log in.

## Testing
- [x] Integration testing on Heroku staging
- [ ] Added new unit tests

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
