### PR TITLE
Use user saved plan to generate plan details page

### DIFF
--- a/assets/js/google_map.js
+++ b/assets/js/google_map.js
@@ -32,8 +32,8 @@ class Label {
 
 // Called by Google Map API
 async function initMap() {
-  // adjust zoom to city level
-  const zoom = 10;
+  // adjust zoom to city level plus one
+  const zoom = 11;
   const mapDiv = document.getElementById("googleMap");
 
   const plan = await getTravelPlan();

--- a/assets/js/place.js
+++ b/assets/js/place.js
@@ -9,7 +9,8 @@ class View {
 }
 
 class Place {
-  constructor(timePeriod, placeName, address, url) {
+  constructor(id, timePeriod, placeName, address, url) {
+    this.id = id;
     this.time_period = timePeriod;
     this.place_name = placeName;
     this.address = address;

--- a/assets/js/search_results.js
+++ b/assets/js/search_results.js
@@ -56,10 +56,12 @@ function planToView(plan, planIndex) {
     []
   );
 
-  $(`#plan-table-${planIndex} tbody tr`).map(function () {
-    const $row = $(this);
+  $(`#plan-table-${planIndex} tbody tr`).map((idx, row) => {
+    const $row = $(row);
+
     view.places.push(
       new Place(
+        plan.places[idx].id,
         $row.find(`:nth-child(1) #interval-${planIndex}`).text().trim(),
         $row.find(":nth-child(2)").find("a").text(),
         $row.find(":nth-child(3)").text(),

--- a/assets/js/show-trip-details.js
+++ b/assets/js/show-trip-details.js
@@ -39,31 +39,26 @@ async function postPlanForUser() {
 
 function planToView(plan) {
   const url = new URL(document.URL);
-  const planId = getPlanId(url);
   const travelDate = getTravelDate(url);
   const view = new View(
     plan.TravelDestination,
     travelDate, // YYYY-MM-DD
-    planId,
+    plan.OriginalPlanID,
     new Date().toISOString(),
     []
   );
   for (const pDetail of plan.PlaceDetails) {
     const {
+      ID: id,
       Name: placeName,
       FormattedAddress: address,
       TimePeriod: timePeriod = "10 - 16", // TODO: use actual time period for each place
       URL: mapURL,
     } = pDetail;
-    const place = new Place(timePeriod, placeName, address, mapURL);
+    const place = new Place(id, timePeriod, placeName, address, mapURL);
     view.places.push(place);
   }
   return view;
-}
-
-function getPlanId(url) {
-  const results = url.pathname.split("/");
-  return results[results.length - 1];
 }
 
 function getTravelDate(url) {

--- a/assets/js/user_profile.js
+++ b/assets/js/user_profile.js
@@ -51,7 +51,7 @@ function renderCard(plan, idx) {
   let showDetailsButton = $("<button>")
     .addClass("btn btn-outline-info float-end m-1")
     .attr("type", "button")
-    .attr("data-planid", `${plan.original_plan_id}`)
+    .attr("data-planid", `${plan.id}`)
     .text("details");
   showDetailsButton.click(showPlanDetails);
   cardBody.append(showDetailsButton);
@@ -78,7 +78,7 @@ function renderFavorites(favorites) {
 
 function showPlanDetails() {
   const planID = this.dataset.planid;
-  window.location = `plans/${planID}`;
+  window.location = `users/${username}/plan/${planID}`;
 }
 
 function getUserPlans() {

--- a/iowrappers/redis_client.go
+++ b/iowrappers/redis_client.go
@@ -627,7 +627,7 @@ func (r *RedisClient) SavePlanningSolutions(ctx context.Context, request *Planni
 			Logger.Error(err)
 			continue
 		}
-		_, recordSaveErr := r.client.Set(ctx, solutionRedisKey, json_, 0).Result()
+		_, recordSaveErr := r.client.Set(ctx, solutionRedisKey, json_, PlanningSolutionsExpirationTime).Result()
 		if recordSaveErr != nil {
 			Logger.Error(err)
 			continue

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -110,6 +110,7 @@ type PlanningPostRequest struct {
 
 // TODO: deprecate Score and ScoreOld fields
 type TripDetailResp struct {
+	OriginalPlanID    string
 	LatLongs          [][2]float64
 	PlaceCategories   []POI.PlaceCategory
 	PlaceDetails      []PlaceDetailsResp
@@ -609,6 +610,7 @@ func (p *MyPlanner) getUserSavedPlanDetails(ctx *gin.Context) {
 	placesCount := len(planDetails.Places)
 
 	resp := TripDetailResp{
+		OriginalPlanID:    planDetails.OriginalPlanID,
 		LatLongs:          make([][2]float64, placesCount),
 		PlaceCategories:   make([]POI.PlaceCategory, placesCount),
 		PlaceDetails:      make([]PlaceDetailsResp, placesCount),
@@ -675,6 +677,7 @@ func (p *MyPlanner) getPlanDetails(ctx *gin.Context) {
 	}
 	travelDate := ctx.DefaultQuery("date", today.Format("2006-01-02")) // yyyy-mm-dd
 	var tripResp = TripDetailResp{
+		OriginalPlanID:    record.ID,
 		LatLongs:          record.PlaceLocations,
 		PlaceCategories:   record.PlaceCategories,
 		PlaceDetails:      make([]PlaceDetailsResp, len(record.PlaceIDs)),

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -629,6 +629,7 @@ func (p *MyPlanner) getUserSavedPlanDetails(ctx *gin.Context) {
 			}
 			resp.LatLongs[i] = [2]float64{place.Location.Latitude, place.Location.Longitude}
 			resp.ShownActive[i] = i == 0
+			resp.PlaceCategories[i] = POI.GetPlaceCategory(place.LocationType)
 
 			details, err := p.placeDetailsResp(ctx, place)
 			if err != nil {
@@ -640,6 +641,13 @@ func (p *MyPlanner) getUserSavedPlanDetails(ctx *gin.Context) {
 	}
 
 	wg.Wait()
+
+	resp.ApiKey = p.MapsClientApiKey
+	jsonOnly, _ := strconv.ParseBool(strings.ToLower(ctx.DefaultQuery("json_only", "false")))
+	if jsonOnly {
+		ctx.JSON(http.StatusOK, resp)
+		return
+	}
 
 	utils.LogErrorWithLevel(p.TripHTMLTemplate.Execute(ctx.Writer, resp), utils.LogError)
 }

--- a/user/user.go
+++ b/user/user.go
@@ -58,6 +58,7 @@ func (p *PersonalFavorites) UnmarshalBinary(data []byte) error {
 
 // TravelPlaceView reflect what users see on Front-end result tables
 type TravelPlaceView struct {
+	ID         string `json:"id"`
 	TimePeriod string `json:"time_period"`
 	PlaceName  string `json:"place_name"`
 	Address    string `json:"address"`


### PR DESCRIPTION
## Description
Related [issue 359](https://github.com/timwangmusic/Vacation-Planner/issues/359). Note that this is a **breaking** change, since users will not be able to check plan details for the previously saved plans.

## Solution
* Enhance user saved plans to generate the plan details page.
* Set expiration time on system generated plans.

## Verifications
* Save a plan from the result page -> go to details -> save the same plan from there -> verify in the profile that there should be no duplicate
* Save a plan directly from the details page -> go to the result page >  save the same plan from there -> verify in the profile that there should be no duplicate

## Testing
- [x] Integration testing on Heroku testing
- [ ] Added new unit tests

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
