### PR TITLE
Add title to markers in Maps

### DIFF
--- a/assets/js/google_map.js
+++ b/assets/js/google_map.js
@@ -39,7 +39,8 @@ async function initMap() {
   const plan = await getTravelPlan();
   const latLngs = makeLatLngs(plan.LatLongs);
   const labels = makeMarkerLabels(plan.PlaceCategories);
-  const options = makeOptions(latLngs, labels);
+  const names = plan.PlaceDetails.map(p => p.Name);
+  const options = makeOptions(latLngs, labels, names);
 
   const { Map } = await google.maps.importLibrary("maps");
   const map = new Map(mapDiv, {
@@ -73,13 +74,14 @@ function makeMarkerLabels(placeCategories) {
   }
 }
 
-function makeOptions(latLngs, labels) {
+function makeOptions(latLngs, labels, names) {
   try {
     opts = [];
     for (let i = 0; i < latLngs.length; i++) {
       opts.push({
         position: latLngs[i],
         label: labels[i],
+        title: names[i],
       });
     }
     return opts;
@@ -135,4 +137,5 @@ const utils = {
   Label: Label,
   placeCategoryToIconCode: placeCategoryToIconCode,
 };
+
 module.exports = utils;

--- a/assets/js/google_map.test.js
+++ b/assets/js/google_map.test.js
@@ -42,6 +42,7 @@ describe("Test Single Marker", () => {
       options: {
         position: [0, 1],
         label: new Label("\uea52"),
+        title: "Tian Tan Park",
       },
     };
 
@@ -251,13 +252,14 @@ describe("Test to create an array of marker options", () => {
     // setup
     const latlngs = [0, 1];
     const labels = ["a", "b"];
+    const names = ["fancy garden", "fun park"];
     const target = [
-      { position: 0, label: "a" },
-      { position: 1, label: "b" },
+      { position: 0, label: "a", title: names[0] },
+      { position: 1, label: "b", title: names[1] },
     ];
 
     // test
-    const result = makeOptions(latlngs, labels);
+    const result = makeOptions(latlngs, labels, names);
     expect(result).toEqual(target);
   });
 });


### PR DESCRIPTION
## Description
Add place names as Map marker titles so users can see them while hanging over the markers.

## Solution
* Set `title` option when constructing markers.

## Testing
- [ ] Integration testing on Heroku staging

