### PR TITLE
Add admin endpoint to send announcement to users

### DIFF
--- a/iowrappers/redis_client.go
+++ b/iowrappers/redis_client.go
@@ -36,7 +36,9 @@ const (
 	CitiesRedisKey                 = "known_cities_ids"
 	KnownCitiesHashMapRedisKey     = "known_cities_name_to_id"
 	MapsLastSearchTimeRedisKey     = "MapsLastSearchTime"
-	PlaceDetailsRedisKeyPrefix     = "place_details:place_ID:"
+	// AnnouncementsRedisKey is a Redis Hash that maps ID to announcement details
+	AnnouncementsRedisKey      = "announcements"
+	PlaceDetailsRedisKeyPrefix = "place_details:place_ID:"
 )
 
 var RedisClientDefaultBlankContext context.Context
@@ -688,6 +690,10 @@ func (r *RedisClient) PlanningSolutions(ctx context.Context, request *PlanningSo
 	}
 
 	return response, nil
+}
+
+func (r *RedisClient) SaveAnnouncement(ctx context.Context, id, data string) error {
+	return r.Get().HSet(ctx, AnnouncementsRedisKey, id, data).Err()
 }
 
 func (r *RedisClient) FetchSingleRecord(context context.Context, redisKey string, response interface{}) error {

--- a/planner/admins.go
+++ b/planner/admins.go
@@ -1,0 +1,60 @@
+package planner
+
+import (
+	"encoding/json"
+	"github.com/gin-contrib/requestid"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/weihesdlegend/Vacation-planner/iowrappers"
+	"github.com/weihesdlegend/Vacation-planner/user"
+	"net/http"
+	"time"
+)
+
+type Announcement struct {
+	ID        string `json:"id"`
+	AdminID   string `json:"admin_id"`
+	Subject   string `json:"subject"`
+	Message   string `json:"message"`
+	Timestamp string `json:"timestamp"`
+}
+
+func (p *MyPlanner) announce(ctx *gin.Context) {
+	requestId := requestid.Get(ctx)
+	ctx.Set(requestIdKey, requestId)
+
+	adminView, err := p.UserAuthentication(ctx, user.LevelAdmin)
+	if err != nil {
+		ctx.JSON(http.StatusForbidden, gin.H{"error": err})
+		return
+	}
+
+	var announcement Announcement
+	err = ctx.ShouldBindJSON(&announcement)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	announcement.AdminID = adminView.ID
+	announcement.ID = uuid.NewString()
+	announcement.Timestamp = time.Now().Format(time.RFC3339)
+
+	if err = p.Mailer.Broadcast(ctx, announcement.Subject, announcement.Message, string(p.Environment)); err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	data, marshalErr := json.Marshal(announcement)
+	if marshalErr != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	err = p.RedisClient.SaveAnnouncement(ctx, announcement.ID, string(data))
+	if err != nil {
+		iowrappers.Logger.Error(err)
+	}
+
+	ctx.JSON(http.StatusOK, announcement)
+}

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -1021,6 +1021,11 @@ func (p *MyPlanner) SetupRouter(serverPort string) *http.Server {
 		{
 			places.GET("/:id", p.GetPlaceDetails)
 		}
+
+		admins := v1.Group("/admins")
+		{
+			admins.POST("/announce", p.announce)
+		}
 	}
 
 	// API endpoints for collecting database statistics


### PR DESCRIPTION
## Description
Add an admin endpoint to send announcements to users.

## Solution
* Only admins can post announcements.
* Announcements are persisted in Redis.
* Concurrently send emails to users.

## Testing
- [x] Integration testing on Heroku testing
- [ ] Added new unit tests

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
