### PR TITLE
Async jobs for generating planning solutions

### DIFF
--- a/iowrappers/jobs.go
+++ b/iowrappers/jobs.go
@@ -1,0 +1,74 @@
+package iowrappers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+type JobStatus string
+
+const (
+	JobStatusCreated   JobStatus = "created"
+	JobStatusRunning   JobStatus = "running"
+	JobStatusFailed    JobStatus = "failed"
+	JobStatusCompleted JobStatus = "completed"
+	JobExpirationTime            = time.Hour
+)
+
+type Job struct {
+	ID          string      `json:"id"`
+	Name        string      `json:"name"`
+	Description string      `json:"description"`
+	Parameters  interface{} `json:"parameters"`
+	Status      JobStatus   `json:"status"`
+	CreatedAt   time.Time   `json:"created_at"`
+	UpdatedAt   time.Time   `json:"updated_at"`
+}
+
+const JobRedisKeyPrefix = "job:"
+
+func (r *RedisClient) UpdateJob(ctx context.Context, job *Job) error {
+	key := JobRedisKeyPrefix + job.ID
+	curTime := time.Now()
+	if exists, err := r.Get().Exists(ctx, key).Result(); err != nil {
+		return err
+	} else if exists == 0 {
+		job.CreatedAt = curTime
+	} else {
+		job.UpdatedAt = curTime
+	}
+
+	data, err := json.Marshal(job)
+	if err != nil {
+		return err
+	}
+
+	return r.Get().Set(ctx, key, string(data), JobExpirationTime).Err()
+}
+
+func (r *RedisClient) GetJob(ctx context.Context, id string) (*Job, error) {
+	key := JobRedisKeyPrefix + id
+	if exists, err := r.Get().Exists(ctx, key).Result(); err != nil {
+		return nil, err
+	} else if exists == 0 {
+		return nil, fmt.Errorf("job %s does not exist", id)
+	}
+
+	result, err := r.Get().Get(ctx, key).Result()
+	if err != nil {
+		return nil, err
+	}
+
+	job := new(Job)
+	if err = json.Unmarshal([]byte(result), job); err != nil {
+		return nil, err
+	}
+	return job, nil
+}
+
+func (r *RedisClient) DeleteJob(ctx context.Context, id string) error {
+	key := JobRedisKeyPrefix + id
+	return r.Get().Del(ctx, key).Err()
+}

--- a/iowrappers/jobs.go
+++ b/iowrappers/jobs.go
@@ -10,11 +10,13 @@ import (
 type JobStatus string
 
 const (
+	JobStatusNew       JobStatus = "new"
 	JobStatusCreated   JobStatus = "created"
 	JobStatusRunning   JobStatus = "running"
 	JobStatusFailed    JobStatus = "failed"
 	JobStatusCompleted JobStatus = "completed"
-	JobExpirationTime            = time.Hour
+
+	JobExpirationTime = time.Hour
 )
 
 type Job struct {
@@ -25,6 +27,13 @@ type Job struct {
 	Status      JobStatus   `json:"status"`
 	CreatedAt   time.Time   `json:"created_at"`
 	UpdatedAt   time.Time   `json:"updated_at"`
+}
+
+// JobExecution helps the service to determine if the job result is still valid
+type JobExecution struct {
+	JobID     string    `json:"job_id"`
+	Status    JobStatus `json:"status"`
+	ExpiresAt time.Time `json:"expires_at"`
 }
 
 const JobRedisKeyPrefix = "job:"

--- a/iowrappers/redis_client.go
+++ b/iowrappers/redis_client.go
@@ -584,7 +584,7 @@ func singleTimeSlotIndex(category POI.PlaceCategory, interval POI.TimeInterval, 
 	return strings.Join(parts, "-"), nil
 }
 
-func generateTravelPlansCacheKey(req *PlanningSolutionsSaveRequest) (string, error) {
+func TravelPlansCacheKey(req *PlanningSolutionsSaveRequest) (string, error) {
 	country, region, city := req.Location.Country, req.Location.AdminAreaLevelOne, req.Location.City
 	slotsIndex, err := timeSlotsIndex(req.PlaceCategories, req.Intervals, req.Weekdays)
 	if err != nil {
@@ -604,7 +604,7 @@ func (r *RedisClient) SavePlanningSolutions(ctx context.Context, request *Planni
 	if len(request.PlanningSolutionRecords) == 0 {
 		return nil
 	}
-	sortedSetKey, keyGenerationErr := generateTravelPlansCacheKey(request)
+	sortedSetKey, keyGenerationErr := TravelPlansCacheKey(request)
 	if keyGenerationErr != nil {
 		Logger.Errorf("failed to generate travel plans cache key, error %s", keyGenerationErr.Error())
 		return keyGenerationErr
@@ -679,7 +679,7 @@ func (r *RedisClient) SavePlanningSolutions(ctx context.Context, request *Planni
 func (r *RedisClient) PlanningSolutions(ctx context.Context, request *PlanningSolutionsSaveRequest) (*PlanningSolutionsResponse, error) {
 	Logger.Debugf("->RedisClient.PlanningSolutions(%v)", request)
 	var response = &PlanningSolutionsResponse{}
-	sortedSetKey, keyGenerationErr := generateTravelPlansCacheKey(request)
+	sortedSetKey, keyGenerationErr := TravelPlansCacheKey(request)
 	if keyGenerationErr != nil {
 		Logger.Error(keyGenerationErr)
 		return response, keyGenerationErr

--- a/iowrappers/redis_client.go
+++ b/iowrappers/redis_client.go
@@ -667,10 +667,8 @@ func (r *RedisClient) SavePlanningSolutions(ctx context.Context, request *Planni
 			return err
 		}
 
-		if err == nil {
-			Logger.Debugf("added the %d travel plan keys to %s", len(members), sortedSetKey)
-		}
 		r.Get().Expire(ctx, sortedSetKey, PlanningSolutionsExpirationTime)
+		Logger.Debugf("added the %d travel plan keys to %s", len(members), sortedSetKey)
 
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"github.com/weihesdlegend/Vacation-planner/iowrappers"
 	"github.com/weihesdlegend/Vacation-planner/utils"
 	"net/url"
@@ -119,14 +120,20 @@ func listenForShutDownServer(ch <-chan os.Signal, svr *manners.GracefulServer, m
 		go myPlanner.ProcessPlanningEvent(worker, wg)
 	}
 
+	myPlanner.Dispatcher.Run(context.Background())
+
 	go func() {
 		// wait for shut-down signal
 		<-ch
 
 		// close worker channels
 		close(myPlanner.PlanningEvents)
+		wg.Wait()
+
+		myPlanner.Dispatcher.Stop()
 	}()
 
-	wg.Wait()
+	myPlanner.Dispatcher.Wait()
+
 	svr.Close()
 }

--- a/planner/dispatcher.go
+++ b/planner/dispatcher.go
@@ -12,14 +12,16 @@ type Dispatcher struct {
 	JobQueue chan *iowrappers.Job
 	workers  []*PlanningSolutionsWorker
 	solver   *Solver
+	c        *iowrappers.RedisClient
 	wg       *sync.WaitGroup
 }
 
-func NewDispatcher(s *Solver) *Dispatcher {
+func NewDispatcher(s *Solver, c *iowrappers.RedisClient) *Dispatcher {
 	return &Dispatcher{
 		JobQueue: make(chan *iowrappers.Job),
 		workers:  make([]*PlanningSolutionsWorker, 0),
 		solver:   s,
+		c:        c,
 		wg:       &sync.WaitGroup{},
 	}
 }
@@ -32,6 +34,7 @@ func (d *Dispatcher) Run(ctx context.Context) {
 		w := &PlanningSolutionsWorker{
 			idx:      i,
 			s:        d.solver,
+			c:        d.c,
 			jobQueue: d.JobQueue,
 			wg:       d.wg,
 		}

--- a/planner/dispatcher.go
+++ b/planner/dispatcher.go
@@ -3,54 +3,49 @@ package planner
 import (
 	"context"
 	"github.com/weihesdlegend/Vacation-planner/iowrappers"
+	"sync"
 )
 
 const NumWorkers = 10
 
 type Dispatcher struct {
-	JobQueue    chan *iowrappers.Job
-	workers     []*PlanningSolutionsWorker
-	done        chan bool
-	solver      *Solver
-	redisClient *iowrappers.RedisClient
+	JobQueue chan *iowrappers.Job
+	workers  []*PlanningSolutionsWorker
+	solver   *Solver
+	wg       *sync.WaitGroup
 }
 
-func NewDispatcher(s *Solver, c *iowrappers.RedisClient) *Dispatcher {
+func NewDispatcher(s *Solver) *Dispatcher {
 	return &Dispatcher{
-		JobQueue:    make(chan *iowrappers.Job),
-		workers:     make([]*PlanningSolutionsWorker, 0),
-		done:        make(chan bool),
-		solver:      s,
-		redisClient: c,
+		JobQueue: make(chan *iowrappers.Job),
+		workers:  make([]*PlanningSolutionsWorker, 0),
+		solver:   s,
+		wg:       &sync.WaitGroup{},
 	}
 }
 
 func (d *Dispatcher) Run(ctx context.Context) {
+	mu := &sync.RWMutex{}
+	ctx = context.WithValue(ctx, iowrappers.ContextRequestUserId, "worker")
+	d.wg.Add(NumWorkers)
 	for i := 0; i < NumWorkers; i++ {
 		w := &PlanningSolutionsWorker{
 			idx:      i,
 			s:        d.solver,
-			c:        d.redisClient,
 			jobQueue: d.JobQueue,
+			wg:       d.wg,
 		}
 		d.workers = append(d.workers, w)
-		w.Run(ctx)
+		w.Run(ctx, mu)
 	}
 }
 
 func (d *Dispatcher) Wait() {
-	go func() {
-		for {
-			select {
-			case <-d.done:
-				close(d.JobQueue)
-			}
-		}
-	}()
+	d.wg.Wait()
 }
 
 func (d *Dispatcher) Stop() {
 	go func() {
-		d.done <- true
+		close(d.JobQueue)
 	}()
 }

--- a/planner/dispatcher.go
+++ b/planner/dispatcher.go
@@ -1,0 +1,56 @@
+package planner
+
+import (
+	"context"
+	"github.com/weihesdlegend/Vacation-planner/iowrappers"
+)
+
+const NumWorkers = 10
+
+type Dispatcher struct {
+	JobQueue    chan *iowrappers.Job
+	workers     []*PlanningSolutionsWorker
+	done        chan bool
+	solver      *Solver
+	redisClient *iowrappers.RedisClient
+}
+
+func NewDispatcher(s *Solver, c *iowrappers.RedisClient) *Dispatcher {
+	return &Dispatcher{
+		JobQueue:    make(chan *iowrappers.Job),
+		workers:     make([]*PlanningSolutionsWorker, 0),
+		done:        make(chan bool),
+		solver:      s,
+		redisClient: c,
+	}
+}
+
+func (d *Dispatcher) Run(ctx context.Context) {
+	for i := 0; i < NumWorkers; i++ {
+		w := &PlanningSolutionsWorker{
+			idx:      i,
+			s:        d.solver,
+			c:        d.redisClient,
+			jobQueue: d.JobQueue,
+		}
+		d.workers = append(d.workers, w)
+		w.Run(ctx)
+	}
+}
+
+func (d *Dispatcher) Wait() {
+	go func() {
+		for {
+			select {
+			case <-d.done:
+				close(d.JobQueue)
+			}
+		}
+	}()
+}
+
+func (d *Dispatcher) Stop() {
+	go func() {
+		d.done <- true
+	}()
+}

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -211,7 +211,7 @@ func (p *MyPlanner) Init(mapsClientApiKey string, redisURL *url.URL, redisStream
 			logger.Fatalf("p failed to create a Mailer: %s", err.Error())
 		}
 	}
-	p.Dispatcher = NewDispatcher(&p.Solver)
+	p.Dispatcher = NewDispatcher(&p.Solver, p.RedisClient)
 	logger.Info("The planner initialization process completes")
 }
 

--- a/planner/streaming.go
+++ b/planner/streaming.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 	"sync"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/weihesdlegend/Vacation-planner/iowrappers"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
@@ -21,10 +20,11 @@ func (p *MyPlanner) planningEventLogging(event iowrappers.PlanningEvent) {
 }
 
 func (p *MyPlanner) ProcessPlanningEvent(worker int, wg *sync.WaitGroup) {
+	defer wg.Done()
 	for event := range p.PlanningEvents {
 		c := cases.Title(language.English)
-		log.Debugf("worker %d processing event for %s", worker, c.String(event.City)+", "+strings.ToUpper(event.Country))
+		iowrappers.Logger.Debugf("worker %d processing event for %s", worker, c.String(event.City)+", "+strings.ToUpper(event.Country))
 		p.RedisClient.CollectPlanningAPIStats(event)
 	}
-	wg.Done()
+	iowrappers.Logger.Debugf("recollected resources for worker %d", worker)
 }

--- a/planner/utils.go
+++ b/planner/utils.go
@@ -3,6 +3,7 @@ package planner
 import (
 	"errors"
 	"github.com/barkimedes/go-deepcopy"
+	"github.com/weihesdlegend/Vacation-planner/iowrappers"
 	"regexp"
 )
 
@@ -54,4 +55,8 @@ func deepCopyAnything[T any](req T, numCopies int) ([]T, error) {
 		result[idx] = copied.(T)
 	}
 	return result, nil
+}
+
+func toSolutionKey(req *PlanningRequest) (string, error) {
+	return iowrappers.TravelPlansCacheKey(toSolutionsSaveRequest(req, nil))
 }

--- a/planner/workers.go
+++ b/planner/workers.go
@@ -2,8 +2,14 @@ package planner
 
 import (
 	"context"
+	"fmt"
 	"github.com/weihesdlegend/Vacation-planner/iowrappers"
+	"sync"
+	"time"
 )
+
+// deduplicate job executions
+var jobExecutions = make(map[string]*iowrappers.JobExecution)
 
 type Worker interface {
 	handleJob(context.Context, *iowrappers.Job) error
@@ -12,35 +18,85 @@ type Worker interface {
 type PlanningSolutionsWorker struct {
 	idx      int
 	s        *Solver
-	c        *iowrappers.RedisClient
 	jobQueue chan *iowrappers.Job
+	wg       *sync.WaitGroup
 }
 
-func (w *PlanningSolutionsWorker) handleJob(ctx context.Context, job *iowrappers.Job) error {
+func (w *PlanningSolutionsWorker) handleJob(ctx context.Context, job *iowrappers.Job, mutex *sync.RWMutex) error {
 	req := job.Parameters.(*PlanningRequest)
 
-	job.Status = iowrappers.JobStatusRunning
-	err := w.c.UpdateJob(ctx, job)
+	jobKey, err := toSolutionKey(req)
 	if err != nil {
+		return err
+	}
+
+	if shouldSkipJobExecution(jobKey, mutex) {
+		return nil
+	}
+
+	if err = createJobExecution(jobKey, job, mutex); err != nil {
+		return err
+	}
+
+	if err = updateJobExecutionStatus(jobKey, mutex, iowrappers.JobStatusRunning); err != nil {
 		return err
 	}
 
 	resp := w.s.Solve(ctx, req)
 	if resp.Err != nil {
-		job.Status = iowrappers.JobStatusFailed
-		err = w.c.UpdateJob(ctx, job)
-		if err != nil {
+		if err = updateJobExecutionStatus(jobKey, mutex, iowrappers.JobStatusFailed); err != nil {
 			return err
 		}
 		return resp.Err
 	}
 
-	job.Status = iowrappers.JobStatusCompleted
-	return w.c.UpdateJob(ctx, job)
+	if err = updateJobExecutionStatus(jobKey, mutex, iowrappers.JobStatusCompleted); err != nil {
+		return err
+	}
+	return nil
 }
 
-func (w *PlanningSolutionsWorker) Run(ctx context.Context) {
+func createJobExecution(jobKey string, job *iowrappers.Job, mutex *sync.RWMutex) error {
+	defer mutex.Unlock()
+	mutex.Lock()
+	if _, ok := jobExecutions[jobKey]; ok {
+		return fmt.Errorf("job execution already exists: %v", jobKey)
+	} else {
+		jobExecutions[jobKey] = &iowrappers.JobExecution{
+			JobID:     job.ID,
+			Status:    iowrappers.JobStatusCreated,
+			ExpiresAt: time.Now().Add(iowrappers.JobExpirationTime),
+		}
+	}
+	return nil
+}
+
+func shouldSkipJobExecution(jobKey string, mu *sync.RWMutex) bool {
+	defer mu.RUnlock()
+	curTime := time.Now()
+	mu.RLock()
+	if execution, ok := jobExecutions[jobKey]; ok {
+		if execution.Status == iowrappers.JobStatusCreated || execution.Status == iowrappers.JobStatusRunning || execution.Status == iowrappers.JobStatusCompleted {
+			return execution.ExpiresAt.After(curTime)
+		}
+	}
+	return false
+}
+
+func updateJobExecutionStatus(jobKey string, mu *sync.RWMutex, newStatus iowrappers.JobStatus) error {
+	defer mu.Unlock()
+	mu.Lock()
+	if _, ok := jobExecutions[jobKey]; ok {
+		jobExecutions[jobKey].Status = newStatus
+	} else {
+		return fmt.Errorf("job to be updated %s does not exist", jobKey)
+	}
+	return nil
+}
+
+func (w *PlanningSolutionsWorker) Run(ctx context.Context, mu *sync.RWMutex) {
 	go func() {
+		defer w.wg.Done()
 		logger := iowrappers.Logger
 
 		for {
@@ -50,13 +106,12 @@ func (w *PlanningSolutionsWorker) Run(ctx context.Context) {
 					logger.Debugf("worker %d is shutting down", w.idx)
 					return
 				}
-				err := w.handleJob(ctx, job)
+				err := w.handleJob(ctx, job, mu)
 				if err != nil {
 					logger.Error(err)
-					w.jobQueue <- job
 					continue
 				}
-				logger.Debugf("worker successfully handled job %s", job.ID)
+				logger.Debugf("worker %d successfully handled job %s: %+v", w.idx, job.ID, job.Parameters)
 			}
 		}
 	}()

--- a/planner/workers.go
+++ b/planner/workers.go
@@ -99,20 +99,15 @@ func (w *PlanningSolutionsWorker) Run(ctx context.Context, mu *sync.RWMutex) {
 		defer w.wg.Done()
 		logger := iowrappers.Logger
 
-		for {
-			select {
-			case job, ok := <-w.jobQueue:
-				if !ok {
-					logger.Debugf("worker %d is shutting down", w.idx)
-					return
-				}
-				err := w.handleJob(ctx, job, mu)
-				if err != nil {
-					logger.Error(err)
-					continue
-				}
-				logger.Debugf("worker %d successfully handled job %s: %+v", w.idx, job.ID, job.Parameters)
+		for job := range w.jobQueue {
+			err := w.handleJob(ctx, job, mu)
+			if err != nil {
+				logger.Error(err)
+				continue
 			}
+			logger.Debugf("worker %d successfully handled job %s: %+v", w.idx, job.ID, job.Parameters)
 		}
+
+		logger.Debugf("worker %d is shutting down", w.idx)
 	}()
 }

--- a/planner/workers.go
+++ b/planner/workers.go
@@ -1,0 +1,63 @@
+package planner
+
+import (
+	"context"
+	"github.com/weihesdlegend/Vacation-planner/iowrappers"
+)
+
+type Worker interface {
+	handleJob(context.Context, *iowrappers.Job) error
+}
+
+type PlanningSolutionsWorker struct {
+	idx      int
+	s        *Solver
+	c        *iowrappers.RedisClient
+	jobQueue chan *iowrappers.Job
+}
+
+func (w *PlanningSolutionsWorker) handleJob(ctx context.Context, job *iowrappers.Job) error {
+	req := job.Parameters.(*PlanningRequest)
+
+	job.Status = iowrappers.JobStatusRunning
+	err := w.c.UpdateJob(ctx, job)
+	if err != nil {
+		return err
+	}
+
+	resp := w.s.Solve(ctx, req)
+	if resp.Err != nil {
+		job.Status = iowrappers.JobStatusFailed
+		err = w.c.UpdateJob(ctx, job)
+		if err != nil {
+			return err
+		}
+		return resp.Err
+	}
+
+	job.Status = iowrappers.JobStatusCompleted
+	return w.c.UpdateJob(ctx, job)
+}
+
+func (w *PlanningSolutionsWorker) Run(ctx context.Context) {
+	go func() {
+		logger := iowrappers.Logger
+
+		for {
+			select {
+			case job, ok := <-w.jobQueue:
+				if !ok {
+					logger.Debugf("worker %d is shutting down", w.idx)
+					return
+				}
+				err := w.handleJob(ctx, job)
+				if err != nil {
+					logger.Error(err)
+					w.jobQueue <- job
+					continue
+				}
+				logger.Debugf("worker successfully handled job %s", job.ID)
+			}
+		}
+	}()
+}


### PR DESCRIPTION
## Description
Previously when a user requests plans that are not generated and stored in the database, the application server computes new plans on the fly. Users will have to wait around 10s to get the results. This is ok for initial queries. When users change any single parameter, such as the price level, they will have to wait since those results are not available even though the only difference is the price level.

In this change, we launch planning solution workers to handle offline jobs. As a start, we enable computing solutions for all the price levels.

## Solution
* Created a worker dispatcher that runs when the server starts running.
* Created planning solutions workers that handle the async jobs.
* Use Golang's `RWMutex` to guard against concurrent job creations and executions.

## Testing
- [x] Integration testing on Heroku staging
- [ ] Added new unit tests

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
