### PR TITLE
Fix precise location display issue in user saved plans

### DIFF
--- a/POI/places.go
+++ b/POI/places.go
@@ -2,9 +2,12 @@ package POI
 
 import (
 	"github.com/modern-go/reflect2"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	"log"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"googlemaps.github.io/maps"
 )
@@ -66,6 +69,11 @@ type Location struct {
 	City              string  `json:"city"`              // name of the city where the location belongs to
 	AdminAreaLevelOne string  `json:"adminAreaLevelOne"` // e.g. state names in the United States
 	Country           string  `json:"country"`           // name of the country where the location belongs to
+}
+
+func (l *Location) String() string {
+	c := cases.Title(language.English)
+	return strings.Join([]string{c.String(l.City), strings.ToUpper(l.AdminAreaLevelOne), c.String(l.Country)}, ", ")
 }
 
 // Address in adr micro-format example:

--- a/assets/js/search_results.js
+++ b/assets/js/search_results.js
@@ -154,10 +154,10 @@ rollUpButton.addEventListener("click", () => {
 
 $(document).ready(async function () {
   {
-    const plans = await getPlans();
-    for (let idx = 0; idx < plans.length; idx++) {
+    const data = await getPlans();
+    for (let idx = 0; idx < data.travel_plans.length; idx++) {
       let btn = document.getElementById("save-" + idx);
-      if (btn != null && plans[idx].saved) {
+      if (btn != null && data.travel_plans[idx].saved) {
         btn.disabled = true;
       }
     }

--- a/assets/js/search_results.js
+++ b/assets/js/search_results.js
@@ -23,7 +23,7 @@ async function postUserFeedback(planIdx) {
   const url = `/v1/users/${username}/feedback`;
 
   const data = await getPlans();
-  const plan = data[planIdx];
+  const plan = data.travel_plans[planIdx];
 
   await fetch(url, {
     method: "POST",
@@ -50,24 +50,25 @@ async function postPlanForUser() {
 
   const data = await getPlans();
   // the number of plans equals the array length in the JSON result
-  numberOfPlans = data.length;
-  const sourcePlan = data[planIndex];
+  numberOfPlans = data.travel_plans.length;
+  const sourcePlan = data.travel_plans[planIndex];
+  const destination = data.travel_destination;
 
   await fetch(url, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
-    body: JSON.stringify(planToView(sourcePlan, planIndex)),
+    body: JSON.stringify(planToView(sourcePlan, planIndex, destination)),
   }).catch((err) => console.error(err));
 
   $(this).attr("disabled", "true");
   $(this).parent().attr("title", "saved!");
 }
 
-function planToView(plan, planIndex) {
+function planToView(plan, planIndex, destination) {
   const url = new URL(document.URL);
-  const location = normalizeLocation(url.searchParams.get("location"));
+  const location = normalizeLocation(destination);
   console.log("The format fixed location is: ", location);
   const view = new View(
     location,

--- a/iowrappers/poi_searcher.go
+++ b/iowrappers/poi_searcher.go
@@ -2,7 +2,10 @@ package iowrappers
 
 import (
 	"context"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	"net/url"
+	"strings"
 	"time"
 
 	gogeonames "github.com/timwangmusic/go-geonames"
@@ -31,6 +34,11 @@ type GeocodeQuery struct {
 	City              string `json:"city"`
 	AdminAreaLevelOne string `json:"admin_area_level_one"`
 	Country           string `json:"country"`
+}
+
+func (gq *GeocodeQuery) String() string {
+	c := cases.Title(language.English)
+	return strings.Join([]string{c.String(gq.City), strings.ToUpper(gq.AdminAreaLevelOne), c.String(gq.Country)}, ", ")
 }
 
 type NearbyCityRequest struct {

--- a/iowrappers/users.go
+++ b/iowrappers/users.go
@@ -65,7 +65,11 @@ const (
 	FindUserByEmail FindUserBy = "FindUserByEmail"
 )
 
-func (r *RedisClient) UpdateSearchHistory(ctx context.Context, location string, userView *user.View) error {
+func (r *RedisClient) UpdateSearchHistory(ctx context.Context, location string, userView *user.View, preciseLocation bool) error {
+	// do not update search history for precise location
+	if preciseLocation {
+		return nil
+	}
 	if userView.ID == "" {
 		if view, err := r.FindUser(ctx, FindUserByName, *userView); err != nil {
 			return err

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -457,15 +457,14 @@ func (p *MyPlanner) processPlanningResp(ctx context.Context, request *PlanningRe
 
 	response.StatusCode = ValidSolutionFound
 	if len(request.Location.City) > 0 {
-		c := cases.Title(language.English)
-		response.TravelDestination = c.String(request.Location.City)
+		response.TravelDestination = request.Location.String()
 	} else {
 		geocodeResp, err := p.Solver.Searcher.ReverseGeocode(ctx, request.Location.Latitude, request.Location.Longitude)
 		if err != nil {
 			response.TravelDestination = "Dream Vacation Destination"
 			return response
 		}
-		response.TravelDestination = geocodeResp.City
+		response.TravelDestination = geocodeResp.String()
 	}
 	return response
 }
@@ -631,7 +630,7 @@ func (p *MyPlanner) getPlanningApi(ctx *gin.Context) {
 
 	jsonOnly := ctx.DefaultQuery("json_only", "false")
 	if jsonOnly != "false" {
-		ctx.JSON(http.StatusOK, planningResp.TravelPlans)
+		ctx.JSON(http.StatusOK, planningResp)
 		return
 	}
 	utils.LogErrorWithLevel(p.ResultHTMLTemplate.Execute(ctx.Writer, planningResp), utils.LogError)

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -611,7 +611,7 @@ func (p *MyPlanner) getPlanningApi(ctx *gin.Context) {
 	c := context.WithValue(ctx, iowrappers.ContextRequestIdKey, requestId)
 	c = context.WithValue(c, iowrappers.ContextRequestUserId, userView.ID)
 	planningResp := p.Planning(c, &planningReq, userView.Username)
-	if err = p.RedisClient.UpdateSearchHistory(c, location, &userView); err != nil {
+	if err = p.RedisClient.UpdateSearchHistory(c, location, &userView, preciseLocation); err != nil {
 		logger.Debug(err)
 	}
 


### PR DESCRIPTION
## Description
The goal of this PR is to fix issue #379 . The cause is we relies on URL parameter when posting user plan views. And when using precise location, this parameter appears in the form of latitude and longitude. And this in turn got saved to user plans as travel destinations.

## Solution
* Use travel destination value from API instead of URL parameter.
* Also disable updating user favorites when using precise location feature.

## Testing
- [x] Integration testing on Heroku staging
- [ ] Added new unit tests

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
