### PR TITLE
Fix: weekday value in planning requests

### DIFF
--- a/iowrappers/redis_client.go
+++ b/iowrappers/redis_client.go
@@ -697,7 +697,10 @@ func (r *RedisClient) PlanningSolutions(ctx context.Context, request *PlanningSo
 
 	ttl := r.Get().TTL(ctx, sortedSetKey).Val()
 
-	userId := ctx.Value(ContextRequestUserId).(string)
+	userId, ok := ctx.Value(ContextRequestUserId).(string)
+	if !ok {
+		userId = "guest"
+	}
 	userPlansSSKey := strings.Join([]string{"user", userId, sortedSetKey}, ":")
 
 	exists, err = r.Get().Exists(ctx, userPlansSSKey).Result()

--- a/planner/transformers.go
+++ b/planner/transformers.go
@@ -89,7 +89,8 @@ func toWeekday(date string) POI.Weekday {
 	month, _ := strconv.Atoi(dateFields[2])
 	day, _ := strconv.Atoi(dateFields[3])
 	t := time.Date(year, time.Month(month), day, 0, 0, 0, 0, time.UTC)
-	return POI.Weekday(t.Weekday())
+	// compensate for the difference between time.Weekday (starts on Sunday) and internal Weekday definition (starts on Monday)
+	return POI.Weekday((t.Weekday() + 6) % 7)
 }
 
 func toPriceLevel(priceLevel string) POI.PriceLevel {


### PR DESCRIPTION
## Description
- Weekday transformation function from date in request is wrong. It doesn't compensate for the fact that the `time.Weekday` type starts with Sunday while the internal Weekday starts on Monday.

## Solution
* Compensate for the difference between `time.Weekday` type and the internal `Weekday` type.

## Testing
- The Louve Museum closes on Tuesday, currently the planner recommends the museum on Tuesday, which is obviously wrong.

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
