### PR TITLE
Persist weekday and time slot info in plan records

### DIFF
--- a/POI/places.go
+++ b/POI/places.go
@@ -28,6 +28,19 @@ func (w Weekday) String() string {
 	return strconv.Itoa(int(w))
 }
 
+func (w Weekday) Name() string {
+	mapping := map[Weekday]string{
+		DateMonday:    "Monday",
+		DateTuesday:   "Tuesday",
+		DateWednesday: "Wednesday",
+		DateThursday:  "Thursday",
+		DateFriday:    "Friday",
+		DateSaturday:  "Saturday",
+		DateSunday:    "Sunday",
+	}
+	return mapping[w]
+}
+
 type PlacePhoto struct {
 	// reference from Google Images
 	Reference string `bson:"reference"`

--- a/iowrappers/redis_client.go
+++ b/iowrappers/redis_client.go
@@ -514,6 +514,8 @@ type PlanningSolutionRecord struct {
 	PlaceAddresses  []string            `json:"place_addresses"`
 	PlaceURLs       []string            `json:"place_urls"`
 	PlaceCategories []POI.PlaceCategory `json:"place_categories"`
+	Weekdays        []string            `json:"weekdays"`
+	TimeSlots       []string            `json:"time_slots"`
 	Destination     POI.Location        `json:"destination"`
 	PlanSpec        string              `json:"plan_spec"`
 }

--- a/planner/solver.go
+++ b/planner/solver.go
@@ -599,7 +599,7 @@ func saveSolutions(ctx context.Context, c *iowrappers.RedisClient, req *Planning
 	planningSolutionRecords := make([]iowrappers.PlanningSolutionRecord, len(solutions))
 
 	for idx, candidate := range solutions {
-		record := toPlanningSolutionRecord(candidate, req.Location)
+		record := toPlanningSolutionRecord(req, candidate, req.Location)
 		planningSolutionRecords[idx] = record
 	}
 

--- a/planner/transformers.go
+++ b/planner/transformers.go
@@ -107,7 +107,17 @@ func toPlacePlanningDetails(name string, slot SlotRequest, url string) PlacePlan
 	}
 }
 
-func toPlanningSolutionRecord(solution PlanningSolution, location POI.Location) iowrappers.PlanningSolutionRecord {
+func slotToWeekday(slot SlotRequest) string {
+	return slot.Weekday.Name()
+}
+
+func slotToTimeslot(slot SlotRequest) string {
+	return slot.TimeSlot.ToString()
+}
+
+func toPlanningSolutionRecord(request *PlanningRequest, solution PlanningSolution, location POI.Location) iowrappers.PlanningSolutionRecord {
+	weekdays := MapSlice(request.Slots, slotToWeekday)
+	timeSlots := MapSlice(request.Slots, slotToTimeslot)
 	return iowrappers.PlanningSolutionRecord{
 		ID:              solution.ID,
 		PlaceIDs:        solution.PlaceIDS,
@@ -118,6 +128,8 @@ func toPlanningSolutionRecord(solution PlanningSolution, location POI.Location) 
 		PlaceAddresses:  solution.PlaceAddresses,
 		PlaceURLs:       solution.PlaceURLs,
 		PlaceCategories: solution.PlaceCategories,
+		Weekdays:        weekdays,
+		TimeSlots:       timeSlots,
 		Destination:     location,
 		PlanSpec:        solution.PlanSpec,
 	}

--- a/test/redis_client_mocks/cached_planning_solutions_test.go
+++ b/test/redis_client_mocks/cached_planning_solutions_test.go
@@ -35,12 +35,16 @@ func TestGetSavedPlanningSolutions_shouldReturnCorrectResults(t *testing.T) {
 				PlaceIDs:   []string{"1", "2"},
 				Score:      200,
 				PlaceNames: []string{"Tian Tan Park", "Yuan Ming Yuan"},
+				Weekdays:   []string{"Wednesday", "Friday"},
+				TimeSlots:  []string{"from 8 to 10", "from 11 to 13"},
 			},
 			{
 				ID:         "33523-32533",
 				PlaceIDs:   []string{"3", "2"},
 				Score:      100,
 				PlaceNames: []string{"Summer Palace", "Yuan Ming Yuan"},
+				Weekdays:   []string{"Wednesday", "Friday"},
+				TimeSlots:  []string{"from 8 to 10", "from 11 to 13"},
 			},
 		},
 		NumPlans: 2,
@@ -83,6 +87,8 @@ func TestGetSavedPlanningSolutions_shouldReturnCorrectResults(t *testing.T) {
 		assert.Equal(t, record.PlaceIDs, planningSolution.PlaceIDs)
 		assert.Equal(t, record.Score, planningSolution.Score)
 		assert.Equal(t, record.PlaceNames, planningSolution.PlaceNames)
+		assert.Equal(t, record.TimeSlots, planningSolution.TimeSlots)
+		assert.Equal(t, record.Weekdays, planningSolution.Weekdays)
 	}
 
 	planningSolutions, err = RedisClient.PlanningSolutions(ctx, request2)


### PR DESCRIPTION
## Description
Plan records do not have time related info. This leads to confusion when front-end needs to post those data in order to have a complete view of the plan.

## Solution
* Weekdays are saved as their English names in the records.
* Time slots are saved with a format `from x to y`.

## Example Record
```
...
"weekdays":["Saturday","Saturday","Saturday","Saturday"],
"time_slots":["from 10 to 12","from 12 to 13","from 14 to 17","from 18 to 20"]
```

## Testing
- [ ] Integration testing on Heroku staging
- [x] Added new unit tests

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
