### PR TITLE
Improve planning API stat collections

### DIFF
--- a/iowrappers/redis_client.go
+++ b/iowrappers/redis_client.go
@@ -25,11 +25,10 @@ import (
 
 const (
 	PlanningSolutionsExpirationTime = 24 * time.Hour
-	PlanningStatExpirationTime      = 24 * time.Hour
 	CityInfoExpirationTime          = 0
 
-	NumVisitorsPlanningAPI         = "visitor_count:planning_APIs"
-	NumVisitorsPrefix              = "visitor_count"
+	NumVisitorsPlanningAPI = "visitor_count:planning_API"
+
 	TravelPlansRedisCacheKeyPrefix = "travel_plans"
 	TravelPlanRedisCacheKeyPrefix  = "travel_plan"
 	CityRedisKeyPrefix             = "city"
@@ -71,28 +70,61 @@ func CreateRedisClient(url *url.URL) *RedisClient {
 	})}
 }
 
-// CollectPlanningAPIStats generates analytics of total number of unique visitors to the planning APIs in the last 24 hours
-// analytics of number of unique users planning for each city
-func (r *RedisClient) CollectPlanningAPIStats(event PlanningEvent) {
+// CollectPlanningAPIStats updates the number of calls to the planning APIs per hour.
+// It also updates API call stats for each city per hour.
+// These keys expire after 30 days.
+func (r *RedisClient) CollectPlanningAPIStats(event PlanningEvent, workerIdx int) {
 	c := r.client
 
 	pipeline := c.Pipeline()
 
-	pipeline.PFAdd(RedisClientDefaultBlankContext, NumVisitorsPlanningAPI, event.User)
-
-	// set expiration time
-	if _, err := pipeline.Exists(RedisClientDefaultBlankContext, NumVisitorsPlanningAPI).Result(); err != nil && errors.Is(err, redis.Nil) {
-		pipeline.Expire(RedisClientDefaultBlankContext, NumVisitorsPlanningAPI, PlanningStatExpirationTime)
+	bucketIdx, err := hourBucketIndex(event.Timestamp)
+	if err != nil {
+		Logger.Debugf("failed to collect API stat %+v", event)
+		return
 	}
 
-	city := strings.ReplaceAll(strings.ToLower(event.City), " ", "_")
-
-	redisKey := strings.Join([]string{NumVisitorsPrefix, event.Country, city}, ":")
-	pipeline.PFAdd(RedisClientDefaultBlankContext, redisKey, event.User)
-
-	if _, err := pipeline.Exec(RedisClientDefaultBlankContext); err != nil {
-		log.Error(err)
+	ctx := context.Background()
+	totalVisitorsKey := strings.Join([]string{NumVisitorsPlanningAPI, bucketIdx}, ":")
+	if exists, err := r.client.Exists(ctx, totalVisitorsKey).Result(); err != nil {
+		Logger.Errorf("failed to check Redis %s for key %s existence", err.Error(), totalVisitorsKey)
+		return
+	} else if exists == 0 {
+		pipeline.Set(ctx, totalVisitorsKey, 0, time.Hour*24*30)
 	}
+	pipeline.Incr(ctx, totalVisitorsKey)
+
+	location := strings.ReplaceAll(strings.Join([]string{event.City, event.Country}, ":"), " ", "_")
+	if event.AdminAreaLevelOne != "" {
+		location = strings.ReplaceAll(strings.Join([]string{event.City, event.AdminAreaLevelOne, event.Country}, ":"), " ", "_")
+	}
+
+	redisKey := strings.Join([]string{NumVisitorsPlanningAPI, location, bucketIdx}, ":")
+	if exists, err := r.client.Exists(ctx, redisKey).Result(); err != nil {
+		Logger.Errorf("failed to check Redis %s for key %s existence", err.Error(), redisKey)
+		return
+	} else if exists == 0 {
+		pipeline.Set(ctx, redisKey, 0, time.Hour*24*30)
+	}
+	pipeline.Incr(ctx, redisKey)
+
+	if _, err = pipeline.Exec(ctx); err != nil {
+		Logger.Debugf("failed to collect API stats %+v: %s", event, err.Error())
+	}
+	Logger.Debugf("API event worker %d successfully handled job", workerIdx)
+}
+
+// hour bucket in UTC standard time
+func hourBucketIndex(timestamp string) (string, error) {
+	t, err := time.Parse(time.RFC3339, timestamp)
+	if err != nil {
+		return "", err
+	}
+
+	t = t.UTC()
+
+	// Convert to YYYYMMDD:HH format
+	return t.Format("20060102:15"), nil
 }
 
 func (r *RedisClient) RemoveKeys(context context.Context, keys []string) (err error) {

--- a/iowrappers/redis_client.go
+++ b/iowrappers/redis_client.go
@@ -27,7 +27,7 @@ const (
 	PlanningSolutionsExpirationTime = 24 * time.Hour
 	CityInfoExpirationTime          = 0
 
-	NumVisitorsPlanningAPI = "visitor_count:planning_API"
+	NumVisitorsPlanningAPI = "visitor_count:planning_api"
 
 	TravelPlansRedisCacheKeyPrefix = "travel_plans"
 	TravelPlanRedisCacheKeyPrefix  = "travel_plan"
@@ -98,6 +98,7 @@ func (r *RedisClient) CollectPlanningAPIStats(event PlanningEvent, workerIdx int
 	if event.AdminAreaLevelOne != "" {
 		location = strings.ReplaceAll(strings.Join([]string{event.City, event.AdminAreaLevelOne, event.Country}, ":"), " ", "_")
 	}
+	location = strings.ToLower(location)
 
 	redisKey := strings.Join([]string{NumVisitorsPlanningAPI, location, bucketIdx}, ":")
 	if exists, err := r.client.Exists(ctx, redisKey).Result(); err != nil {

--- a/iowrappers/users.go
+++ b/iowrappers/users.go
@@ -34,10 +34,11 @@ type GoogleOAuthResponse struct {
 }
 
 type PlanningEvent struct {
-	User      string `json:"user"`
-	City      string `json:"city"`
-	Country   string `json:"country"`
-	Timestamp string `json:"timestamp"`
+	User              string `json:"user"`
+	City              string `json:"city"`
+	Country           string `json:"country"`
+	AdminAreaLevelOne string `json:"admin_area_level_one"`
+	Timestamp         string `json:"timestamp"`
 }
 
 type VerificationResult struct {

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -415,10 +415,11 @@ func (p *MyPlanner) processPlanningResp(ctx context.Context, request *PlanningRe
 
 	// logging planning API usage for valid requests
 	event := iowrappers.PlanningEvent{
-		User:      user,
-		Country:   request.Location.Country,
-		City:      request.Location.City,
-		Timestamp: time.Now().Format(time.RFC3339),
+		User:              user,
+		Country:           request.Location.Country,
+		City:              request.Location.City,
+		AdminAreaLevelOne: request.Location.AdminAreaLevelOne,
+		Timestamp:         time.Now().Format(time.RFC3339),
 	}
 	p.PlanningEvents <- event
 	p.planningEventLogging(event)

--- a/planner/streaming.go
+++ b/planner/streaming.go
@@ -1,12 +1,9 @@
 package planner
 
 import (
-	"strings"
 	"sync"
 
 	"github.com/weihesdlegend/Vacation-planner/iowrappers"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 )
 
 func (p *MyPlanner) planningEventLogging(event iowrappers.PlanningEvent) {
@@ -22,9 +19,7 @@ func (p *MyPlanner) planningEventLogging(event iowrappers.PlanningEvent) {
 func (p *MyPlanner) ProcessPlanningEvent(worker int, wg *sync.WaitGroup) {
 	defer wg.Done()
 	for event := range p.PlanningEvents {
-		c := cases.Title(language.English)
-		iowrappers.Logger.Debugf("worker %d processing event for %s", worker, c.String(event.City)+", "+strings.ToUpper(event.Country))
-		p.RedisClient.CollectPlanningAPIStats(event)
+		p.RedisClient.CollectPlanningAPIStats(event, worker)
 	}
 	iowrappers.Logger.Debugf("recollected resources for worker %d", worker)
 }

--- a/planner/workers.go
+++ b/planner/workers.go
@@ -12,7 +12,7 @@ import (
 var jobExecutions = make(map[string]*iowrappers.JobExecution)
 
 type Worker interface {
-	handleJob(context.Context, *iowrappers.Job) error
+	handleJob(context.Context, *iowrappers.Job, *sync.RWMutex) error
 }
 
 type PlanningSolutionsWorker struct {


### PR DESCRIPTION
## Description
Currently the planning API stat uses Redis hyper log, and the values are inaccurate.

## Solution
* Create hour bucket with UTC time as key.
* Update API call count as request comes in.

## Testing
- [ ] Integration testing on Heroku staging
- [ ] Added new unit tests

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
