### PR TITLE
Enhancement: improve formatting for plan summary

### DIFF
--- a/assets/js/search_results.js
+++ b/assets/js/search_results.js
@@ -162,11 +162,20 @@ for (let planIndex = 0; planIndex < numberOfPlans; planIndex++) {
     console.log("generating plan summary...");
     $(`#gen-summary-${planIndex}`).prop("disabled", true);
     const resp = await getPlanSummaryResponse(planIndex);
-    $(`#modal-body-${planIndex}`).text(resp.message);
+    $(`#modal-body-${planIndex}`).html(summaryToHTML(resp.message));
     $(`#gen-summary-${planIndex}`)
       .prop("disabled", false)
       .text("regenerate summary");
   });
+}
+
+function summaryToHTML(message) {
+  let result = ['<ul>'];
+  for (const line of message.trim().split('. ')) {
+    result.push('<li>' + line.trim() + '</li>');
+  }
+  result.push('</ul>');
+  return result.join('');
 }
 
 $(".reload-btn").each(function (_, element) {


### PR DESCRIPTION
## Description
The new format show plan summary in bullet points in an unordered list.

## Solution
* Reformat per description
<img width="491" alt="Screenshot 2024-11-03 at 6 50 58 PM" src="https://github.com/user-attachments/assets/d5a3f0b5-049a-4223-b8af-69f5d203ee70">


## Testing
- [ ] Integration testing on Heroku staging
- [ ] Added new unit tests

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
