### PR TITLE
fix: image location for location input with two parts

### DIFF
--- a/assets/js/search_results.js
+++ b/assets/js/search_results.js
@@ -43,7 +43,19 @@ async function getImageForLocation() {
   console.log("calling image generation function...");
   const location = getLocation();
   const url = `/v1/gen_image`;
-  let parts = location.split(", ");
+  const parts = location.split(",").map((str) => str.trim());
+  if (parts.length < 2 || parts.length > 3) {
+    console.log("wrong location input format", location);
+    $("#loadingSpinner").hide();
+    return;
+  }
+
+  let city = parts[0];
+  let country = parts[parts.length - 1];
+  let adminAreaLevelOne = "cities";
+  if (parts.length == 3) {
+    adminAreaLevelOne = parts[1];
+  }
 
   await fetch(url, {
     method: "POST",
@@ -51,9 +63,9 @@ async function getImageForLocation() {
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      city: parts[0],
-      adminAreaLevelOne: parts[1],
-      country: parts[2],
+      city: city,
+      adminAreaLevelOne: adminAreaLevelOne,
+      country: country,
     }),
   })
     .then((response) => response.json())


### PR DESCRIPTION
## Description
When users use locations with only city followed by country (e.g. Paris, France), the image is stored under `/` with the current implementation. In this fix, the images will be stored in `country/cities/city_name` directory in the S3 bucket.

## Solution
* Add a simple validation in the image fetcher.
* Add a fixed filler for location inputs without `admin area one`.

## Testing
- [ ] Integration testing on Heroku staging
- [ ] Added new unit tests

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
