### PR TITLE
feat: redirect to 404 page when plan details not found

### DIFF
--- a/iowrappers/redis_client.go
+++ b/iowrappers/redis_client.go
@@ -786,8 +786,12 @@ func (r *RedisClient) SaveAnnouncement(ctx context.Context, id, data string) err
 
 func (r *RedisClient) FetchSingleRecord(context context.Context, redisKey string, response interface{}) error {
 	json_, err := r.client.Get(context, redisKey).Result()
+	Logger.Debugf("redis server find no result for key: %s", redisKey)
 	if err != nil {
-		return fmt.Errorf("[request_id: %s] redis server find no result for key: %s", context.Value(ContextRequestIdKey), redisKey)
+		if errors.Is(err, redis.Nil) {
+			return redis.Nil
+		}
+		return fmt.Errorf("failed to fetch result for key %s: %w", redisKey, err)
 	}
 	err = json.Unmarshal([]byte(json_), response)
 	if err != nil {


### PR DESCRIPTION
## Description
When plans expire, users will be redirected to the 404 page.

## Solution
* Directly calling the 404 handler will not render CSS correctly.

## Testing
- [ ] Integration testing on Heroku staging
- [ ] Added new unit tests

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
