### PR TITLE
perf: improve maps nearby search

### DIFF
--- a/iowrappers/nearby_search.go
+++ b/iowrappers/nearby_search.go
@@ -119,7 +119,8 @@ func (c *MapsClient) extensiveNearbySearch(ctx context.Context, maxRequestTimes 
 			var searchResp maps.PlacesSearchResponse
 			searchResp, err = c.GoogleMapsNearbySearchWrapper(ctx, searchReq)
 			if err != nil {
-				Logger.Error(fmt.Errorf("places nearby search with Maps error: %w", err))
+				Logger.Error(fmt.Errorf("places nearby search with Maps failed for place type %s with error: %w",
+					placeType, err))
 				// we should still retry for the same place type but with a maximum being maxRequestTimes
 				continue
 			}


### PR DESCRIPTION
## Description
Improve error handling of the core maps search function and remove sleep time between requests to the Maps services.

## Solution
* Instead of early return when error happens, skip the current place type and wait for the next attempt.
* Remove sleep between requests.

## Testing
- [x] Integration testing on Heroku staging
- [ ] Added new unit tests

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
