### PR TITLE
feat: add location image download button

### DIFF
--- a/assets/js/search_results.js
+++ b/assets/js/search_results.js
@@ -71,7 +71,19 @@ async function getImageForLocation() {
     .then((response) => response.json())
     .then((data) => {
       $("#generated-img").attr("src", data.photo).show();
-
+      $("#gen-img-download-btn")
+        .off("click")
+        .click(() => {
+          console.log("downloading location image...");
+          const url = data.photo;
+          const a = document.createElement("a");
+          a.href = url;
+          a.download = "downloaded-city-image.png";
+          document.body.appendChild(a);
+          a.click();
+          document.body.removeChild(a);
+        })
+        .show();
       $("#loadingSpinner").hide();
     })
     .catch(console.error);

--- a/assets/templates/search_results_layout_template.html
+++ b/assets/templates/search_results_layout_template.html
@@ -2,9 +2,9 @@
 <html lang="en" data-theme="light">
   <head>
     <script>
-      var currentTheme = localStorage.getItem('theme');
+      var currentTheme = localStorage.getItem("theme");
 
-      if (currentTheme !== null && currentTheme === 'dark') {
+      if (currentTheme !== null && currentTheme === "dark") {
         document.documentElement.setAttribute("data-theme", "dark");
       }
     </script>
@@ -68,13 +68,26 @@
 
         <h1>Vacation Plans for {{.TravelDestination}}</h1>
       </div>
-      <div id="loadingSpinner" class="text-center" style="display: block;">
+      <div id="loadingSpinner" class="text-center" style="display: block">
         <div class="spinner-border text-primary" role="status">
           <span class="visually-hidden">Loading Image...</span>
         </div>
       </div>
-      <div class="m-1 d-flex justify-content-center">
-        <img id="generated-img" style="height: 512px; width: 512px; display: none" />
+      <div
+        class="m-1 d-grid justify-content-center"
+        style="grid-template-columns: auto auto; align-items: end; gap: 0.5rem"
+      >
+        <img
+          id="generated-img"
+          style="height: auto; max-width: 100%; display: none"
+        />
+        <div class="button" id="gen-img-download-btn" style="display: none">
+          <span
+            class="material-icons"
+            style="color: #24c1e0; cursor: pointer; align-self: end"
+            >download</span
+          >
+        </div>
       </div>
 
       {{if .Err}} Error: {{.Err}}<br />
@@ -225,7 +238,9 @@
                     <td class="col-4 col-md-3">
                       <a href="{{.URL}}">{{.PlaceName}}</a>
                     </td>
-                    <td class="d-none d-md-block" style="color: #0d6efd">{{.Address}}</td>
+                    <td class="d-none d-md-block" style="color: #0d6efd">
+                      {{.Address}}
+                    </td>
                   </tr>
                   {{end}}
                 </tbody>


### PR DESCRIPTION
## Description
Add a download button for users to download the location image.

## Solution
* Since we have S3 signed URL, we just need to add a new download button and assign the same URL to its `download` property. 
* Use material icons.
* Also trying to fix image display issue on smaller devices.

## Testing
- [x] Integration testing on Heroku staging
~~[ ] Added new unit tests~~

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
