### PR TITLE
feat: load more results in the plan results page

### DIFF
--- a/assets/templates/search_results_layout_template.html
+++ b/assets/templates/search_results_layout_template.html
@@ -251,17 +251,25 @@
         </div>
         {{end}}
       </div>
-      <span
-        class="d-inline-block float-end"
-        data-bs-toggle="tooltip"
-        data-bs-placement="left"
-        title="Scroll to top"
-      >
-        <button class="btn btn-outline-info" id="scroll-to-top" type="button">
-          <i class="fa-solid fa-angles-up"></i>
+      <div class="text-center my-3">
+        <button class="btn btn-primary" id="load-more-btn" type="button">
+          Load More...
         </button>
-      </span>
+      </div>
     </div>
+
+    <!-- Fixed position scroll to top button -->
+    <button
+      class="btn btn-outline-info"
+      id="scroll-to-top"
+      type="button"
+      style="position: fixed; bottom: 20px; right: 20px; z-index: 1000;"
+      data-bs-toggle="tooltip"
+      data-bs-placement="left"
+      title="Scroll to top"
+    >
+      <i class="fa-solid fa-angles-up"></i>
+    </button>
 
     <script type="module" src="assets/js/user.js"></script>
     <script type="module" src="assets/js/search_results.js"></script>


### PR DESCRIPTION
## Description
Previously, we rely on the mechanism that in order for users to see a set of new plans they have to click on the dislike button. So that the "refresh" will load a new set of travel plans. This change aims to improve the user experience by providing users options to load more plans (up to 15 at the moment). 

## Solution
-   Pre-fetches 10 extra plans beyond what's displayed for instant "load more"
-   Dynamically renders new plans when clicking "Load More"
-   Button automatically hides when all plans are displayed
-   Scroll-to-top button now fixed position in bottom-right corner
-   Maintains all existing functionality (like/dislike, save, refresh, etc.)

## Testing
- [x] Integration testing on Heroku staging
- [ ] Added new unit tests

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
